### PR TITLE
Minor config GUI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 ### Changed
 
 - Movement speed options now use sliders instead of text fields ([#190](https://github.com/MinecraftFreecam/Freecam/pull/190)).
+- Redundant collision options are now dynamically hidden ([#121](https://github.com/MinecraftFreecam/Freecam/pull/121)).
 
 ### Removed
 

--- a/common/src/main/java/net/xolt/freecam/config/ModConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModConfig.java
@@ -121,49 +121,52 @@ public class ModConfig implements ConfigData {
     }
 
     public enum FlightMode implements SelectionListEntry.Translatable {
-        CREATIVE("text.autoconfig.freecam.option.movement.flightMode.creative"),
-        DEFAULT("text.autoconfig.freecam.option.movement.flightMode.default");
+        CREATIVE("creative"),
+        DEFAULT("default");
 
-        private final String name;
+        private final String key;
 
         FlightMode(String name) {
-            this.name = name;
+            this.key = "text.autoconfig.freecam.option.movement.flightMode." + name;
         }
 
-        public String getKey() {
-            return name;
+        @Override
+        public @NotNull String getKey() {
+            return key;
         }
     }
 
     public enum InteractionMode implements SelectionListEntry.Translatable {
-        CAMERA("text.autoconfig.freecam.option.utility.interactionMode.camera"),
-        PLAYER("text.autoconfig.freecam.option.utility.interactionMode.player");
+        CAMERA("camera"),
+        PLAYER("player");
 
-        private final String name;
+        private final String key;
 
         InteractionMode(String name) {
-            this.name = name;
+            this.key = "text.autoconfig.freecam.option.utility.interactionMode." + name;
         }
 
-        public String getKey() {
-            return name;
+        @Override
+        public @NotNull String getKey() {
+            return key;
         }
     }
 
     public enum Perspective implements SelectionListEntry.Translatable {
-        FIRST_PERSON("text.autoconfig.freecam.option.visual.perspective.firstPerson"),
-        THIRD_PERSON("text.autoconfig.freecam.option.visual.perspective.thirdPerson"),
-        THIRD_PERSON_MIRROR("text.autoconfig.freecam.option.visual.perspective.thirdPersonMirror"),
-        INSIDE("text.autoconfig.freecam.option.visual.perspective.inside");
+        FIRST_PERSON("firstPerson"),
+        THIRD_PERSON("thirdPerson"),
+        THIRD_PERSON_MIRROR("thirdPersonMirror"),
+        INSIDE("inside");
 
-        private final String name;
+        private final String key;
 
         Perspective(String name) {
-            this.name = name;
+            this.key = "text.autoconfig.freecam.option.visual.perspective." + name;
         }
 
-        public String getKey() {
-            return name;
+        @Override
+        public @NotNull String getKey() {
+            return key;
         }
     }
 }

--- a/common/src/main/java/net/xolt/freecam/config/ModConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModConfig.java
@@ -55,10 +55,10 @@ public class ModConfig implements ConfigData {
     public CollisionConfig collision = new CollisionConfig();
     public static class CollisionConfig {
         @ConfigEntry.Gui.Tooltip
-        public boolean ignoreTransparent = true;
+        public boolean ignoreTransparent = false;
 
         @ConfigEntry.Gui.Tooltip
-        public boolean ignoreOpenable = true;
+        public boolean ignoreOpenable = false;
 
         @VariantTooltip(variant = "normal", count = 2)
         @VariantTooltip(variant = "modrinth", count = 3)

--- a/common/src/main/java/net/xolt/freecam/config/gui/AutoConfigExtensions.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/AutoConfigExtensions.java
@@ -22,6 +22,7 @@ public class AutoConfigExtensions {
 
     public static void apply(Class<? extends ConfigData> configClass) {
         GuiRegistry registry = AutoConfig.getGuiRegistry(configClass);
+        Requirements.apply(registry);
         ModBindingsConfigImpl.apply(registry);
         VariantTooltipImpl.apply(registry);
         BoundedContinuousImpl.apply(registry);

--- a/common/src/main/java/net/xolt/freecam/config/gui/Requirements.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/Requirements.java
@@ -1,0 +1,67 @@
+package net.xolt.freecam.config.gui;
+
+import me.shedaniel.autoconfig.gui.registry.GuiRegistry;
+import me.shedaniel.clothconfig2.api.ValueHolder;
+import me.shedaniel.clothconfig2.gui.entries.BooleanListEntry;
+import net.xolt.freecam.variant.api.BuildVariant;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+import static java.lang.Boolean.FALSE;
+
+@SuppressWarnings("UnstableApiUsage")
+class Requirements {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private static ValueHolder<Boolean> ignoreAllWidget;
+
+    private Requirements() {}
+
+    static void apply(GuiRegistry guiRegistry) {
+        // FIXME These transformers assume that no subsequent GUI transformers will replace
+        //       the widgets. That's fine, so long as nothing changes, however a dedicated
+        //       AutoConfig requirements API would be better.
+        //
+        // NOTE The Cloth Config Requirements API is currently marked "unstable", although
+        //      significant changes seem unlikely.
+
+        // Register a transformer to capture the ignoreAll GUI
+        guiRegistry.registerPredicateTransformer((guis, i18n, field, config, defaults, registry) -> {
+            // Filter out unrelated widgets, such as PrefixText.
+            // Also allows us to safely cast.
+            List<BooleanListEntry> widgets = guis.stream()
+                    .filter(BooleanListEntry.class::isInstance)
+                    .map(BooleanListEntry.class::cast)
+                    .toList();
+            if (widgets.isEmpty()) {
+                LOGGER.error("Unable to find ignoreAll widget.");
+                return guis;
+            }
+            if (widgets.size() > 1) {
+                LOGGER.warn("Multiple ignoreAll widgets, choosing first.");
+            }
+            ignoreAllWidget = widgets.get(0);
+            return guis;
+        }, field -> field.getName().equals("ignoreAll"));
+
+        // Register a transformer to set requirements for ignoreTransparent & ignoreOpenable
+        guiRegistry.registerPredicateTransformer((guis, i18n, field, config, defaults, registry) -> {
+            if (BuildVariant.getInstance().name().equals("modrinth")) {
+                // Disabling doesn't make sense on the modrinth build
+                return guis;
+            }
+            guis.stream()
+                    .filter(BooleanListEntry.class::isInstance)
+                    .map(BooleanListEntry.class::cast)
+                    .forEach(gui -> gui.setRequirement(Requirements::notIgnoreAll));
+            return guis;
+        }, field -> List.of("ignoreTransparent", "ignoreOpenable").contains(field.getName()));
+    }
+
+    // Requirement handler: require ignoreAll is set to "No"
+    private static boolean notIgnoreAll() {
+        return ignoreAllWidget == null || FALSE.equals(ignoreAllWidget.getValue());
+    }
+}


### PR DESCRIPTION
Two relatively minor improvements to the config GUI.

Other than speed scale, none of these affect how config is stored, saved or loaded. Out of bounds numbers are still permidded and disabled options can still be modified in the config file or by modifying and saving in code. Only the GUI widget is actually disabled as a visual cue.

## Collision mode requirements

Taking advantage of the experimental Cloth Config requirements API added in shedaniel/cloth-config#204,  "Ignore Transparent" and "Ignore Openable" are now _disabled_ when "Ignore All" is switched "ON".

### Alternative approach

Rather than _disabling_ "Ignore Transparent" and "Ignore Openable", we could also _hide_ them instead. This would probably need some text added to hint at the hidden options.

We could also move them into a nested sub-category and disable _that_. The current implementation is the simplest option, but I'm open to doing things differently.

### Implementation note

It's technically a bit hacky to the AutoConfig transformer system for this;

The main issue you might run into is run order: another transformer could run after ours, which could decide to remove/replaced the widget we've captured, rather than mutating it.

Luckily AutoConfig will never do that to boolean entries and we won't either. So for us it's a non-issue.   
  _Incidentally, that edge-case is why I opened shedaniel/cloth-config#215._

I've left a FIXME note as a reminder anyway. If I ever finish a Requirements API for AutoConfig, we can move over to that once its merged.

## Movement speed sliders

Moved to #190 

<details><summary>Details</summary>
<p>

Replace the text-entry widgets with number slider widgets.

This meant I had to a) set an upper bound on the value and b) convert to a scaled up `int`.

Some users will still have the old scaled-down values and they will move very slowly unless they reset/adjust their settings after upgrading.

We could avoid that by renaming the fields, however the current names are pretty good (`horizontalSpeed` & `verticalSpeed`)...

</p>
</details> 

## Minor Enum cleanup

I almost pushed this to #122, but figured this PR was more topical. This minor tweak was made while working on #116, but felt unrelated to the core change of that PR. 

## Demo

https://github.com/hashalite/Freecam/assets/5046562/d88de289-9971-4d82-ab1b-74b2d406c11f
