### PR TITLE
Potential workaround for #110

### DIFF
--- a/common/src/main/java/net/xolt/freecam/util/FreeCamera.java
+++ b/common/src/main/java/net/xolt/freecam/util/FreeCamera.java
@@ -210,6 +210,9 @@ public class FreeCamera extends ClientPlayerEntity {
 
     @Override
     public void tickMovement() {
+        // Potential workaround for #110
+        noClip = ModConfig.INSTANCE.collision.ignoreAll;
+
         if (ModConfig.INSTANCE.movement.flightMode.equals(ModConfig.FlightMode.DEFAULT)) {
             getAbilities().setFlySpeed(0);
             Motion.doMotion(this, ModConfig.INSTANCE.movement.horizontalSpeed, ModConfig.INSTANCE.movement.verticalSpeed);


### PR DESCRIPTION
I'm still completely unable to reproduce #110, however I've [witnessed](https://youtube.com/clip/UgkxLVToBtl-Lm1o4_YG--DBAKW-SIe27nIc) it affecting an old version of this mod on a @TangoTek stream.

I have **no idea if this PR actually fixes the issue**. I've posted test builds in #110 along with additional questions, with the hope that we might get some more insight.

As I mentioned in [this comment](https://github.com/hashalite/Freecam/issues/110#issuecomment-1837273984), I suspect some other mod may be optimising collision checks and somehow messing with the mixin introduced in #71. I could be totally wrong about this though.

Notably, the version I witnessed on stream was `1.1.10+1.20`, but he was playing on a `1.20.2` server. Another potential cause might be the version mis-match, similar to #92, however in my testing that wasn't enough to reproduce the issue (at least in singleplayer).

It is possible that [this change](https://github.com/hashalite/Freecam/commit/b2f6429c37d82f8d6ff47efda3f08048402cb34e#diff-de0f8c8ad4ae6e5f24247dc63ad9c0ddc3ab4891dfa05f16ebb9bbad0ba114b5) has already fixed (or partially fixed) the issue.