### PR TITLE
Mod platform publishing task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,37 +52,6 @@ changelog {
     headerParserRegex = ~/(\d+(?:\.\d+)+)/
 }
 
-subprojects {
-    apply plugin: "dev.architectury.loom"
-
-    loom {
-        accessWidenerPath = project(":common").file "src/main/resources/freecam.accesswidener"
-
-        runs {
-            client {
-                // Pretty run-config name
-                // Note: we can't disable the (:path) suffix
-                // https://github.com/architectury/architectury-loom/blob/5b3e7c72b665f7eb38c23ceb677027acdc867398/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java#L117
-                configName "Run"
-            }
-            remove server // We only need client runs
-        }
-
-        silentMojangMappingsLicense()
-    }
-
-    dependencies {
-        def parchmentAppendix = rootProject.parchment_version.split('-')[0]
-        def parchmentVersion = rootProject.parchment_version.split('-')[1]
-
-        minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
-        mappings loom.layered() {
-            officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-${parchmentAppendix}:${parchmentVersion}@zip")
-        }
-    }
-}
-
 allprojects {
     apply plugin: "java"
     apply plugin: "architectury-plugin"
@@ -125,5 +94,36 @@ allprojects {
 
     jar {
         from "LICENSE"
+    }
+}
+
+subprojects {
+    apply plugin: "dev.architectury.loom"
+
+    loom {
+        accessWidenerPath = project(":common").file "src/main/resources/freecam.accesswidener"
+
+        runs {
+            client {
+                // Pretty run-config name
+                // Note: we can't disable the (:path) suffix
+                // https://github.com/architectury/architectury-loom/blob/5b3e7c72b665f7eb38c23ceb677027acdc867398/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java#L117
+                configName "Run"
+            }
+            remove server // We only need client runs
+        }
+
+        silentMojangMappingsLicense()
+    }
+
+    dependencies {
+        def parchmentAppendix = rootProject.parchment_version.split('-')[0]
+        def parchmentVersion = rootProject.parchment_version.split('-')[1]
+
+        minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
+        mappings loom.layered() {
+            officialMojangMappings()
+            parchment("org.parchmentmc.data:parchment-${parchmentAppendix}:${parchmentVersion}@zip")
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import net.fabricmc.loom.task.RemapJarTask
+import org.jetbrains.changelog.Changelog
 
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
@@ -148,7 +149,23 @@ subprojects {
             gameVersions = [ rootProject.minecraft_version ]
             curseEnvironment = "client"
             loaders = [ project.name ]
-            changelog = ""
+
+            // Get the changelog entry using the changelog plugin
+            changelog = provider {
+                def plugin = rootProject.changelog
+                def version = rootProject.mod_version
+                if (!plugin.has(version)) {
+                    logger.warn "No changelog for \"${version}\". Using \"unreleased\" instead."
+                }
+
+                def logEntry = (plugin.getOrNull(version) ?: plugin.getUnreleased())
+                        .withHeader(false)
+                        .withLinks(false)
+                        .withEmptySections(false)
+                        .withSummary(true)
+
+                return plugin.renderItem(logEntry, Changelog.OutputType.MARKDOWN)
+            }
 
             artifact = tasks.remapJar
             setPlatformArtifact "modrinth", tasks.remapModrinthJar

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
+import net.fabricmc.loom.task.RemapJarTask
+
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
     id "dev.architectury.loom" version "1.4-SNAPSHOT" apply false
+    id "com.hypherionmc.modutils.modpublisher" version "2.0.5" apply false
     id "com.github.johnrengelman.shadow" version "7.1.2" apply false
     id "org.jetbrains.changelog" version "2.2.0"
 }
@@ -125,5 +128,41 @@ subprojects {
             officialMojangMappings()
             parchment("org.parchmentmc.data:parchment-${parchmentAppendix}:${parchmentVersion}@zip")
         }
+    }
+
+    if (rootProject.enabled_platforms.split(',').contains project.name) {
+        apply plugin: "com.hypherionmc.modutils.modpublisher"
+
+        // Ensure this task exists, since we need to publish its output
+        tasks.maybeCreate("remapModrinthJar", RemapJarTask)
+
+        publisher {
+            curseID = "557076"
+            modrinthID = "XeEZ3fK2"
+
+            // Format display name "[Fabric] Freecam 1.2.2 for MC 1.20.4"
+            displayName = "[${project.name.capitalize()}] ${rootProject.name.capitalize()} ${rootProject.mod_version} for MC ${rootProject.minecraft_version}"
+            version = project.version
+            versionType = rootProject.release_type
+            // TODO we could set a list of compatible versions, not just the one we're building against:
+            gameVersions = [ rootProject.minecraft_version ]
+            curseEnvironment = "client"
+            loaders = [ project.name ]
+            changelog = ""
+
+            artifact = tasks.remapJar
+            setPlatformArtifact "modrinth", tasks.remapModrinthJar
+
+            [ curseDepends, modrinthDepends ].each {
+                it.embedded "cloth-config"
+            }
+
+            apiKeys {
+                curseforge findProperty("curseforge_token") ?: System.getenv("CURSEFORGE_TOKEN") ?: ""
+                modrinth findProperty("modrinth_token") ?: System.getenv("MODRINTH_TOKEN") ?: ""
+            }
+        }
+
+        tasks.publish.dependsOn tasks.publishMod
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,10 +157,12 @@ subprojects {
                 it.embedded "cloth-config"
             }
 
+            def dummy = "default"
             apiKeys {
-                curseforge findProperty("curseforge_token") ?: System.getenv("CURSEFORGE_TOKEN") ?: ""
-                modrinth findProperty("modrinth_token") ?: System.getenv("MODRINTH_TOKEN") ?: ""
+                curseforge findProperty("curseforge_token") ?: System.getenv("CURSEFORGE_TOKEN") ?: dummy
+                modrinth findProperty("modrinth_token") ?: System.getenv("MODRINTH_TOKEN") ?: dummy
             }
+            debug = [ apiKeys.curseforge, apiKeys.modrinth ].contains dummy
         }
 
         tasks.publish.dependsOn tasks.publishMod

--- a/build.gradle
+++ b/build.gradle
@@ -145,8 +145,6 @@ subprojects {
             displayName = "[${project.name.capitalize()}] ${rootProject.name.capitalize()} ${rootProject.mod_version} for MC ${rootProject.minecraft_version}"
             version = project.version
             versionType = rootProject.release_type
-            // TODO we could set a list of compatible versions, not just the one we're building against:
-            gameVersions = [ rootProject.minecraft_version ]
             curseEnvironment = "client"
             loaders = [ project.name ]
 
@@ -165,6 +163,21 @@ subprojects {
                         .withSummary(true)
 
                 return plugin.renderItem(logEntry, Changelog.OutputType.MARKDOWN)
+            }
+
+            // List the current `minecraft_version`, everything in `supported_mc_versions`, &
+            // everything in the current mod loader's `*_supported_mc_versions` as a supported version
+            gameVersions = provider {
+                String prop = "supported_mc_versions"
+                String primary = rootProject.property("minecraft_version")
+                String common = rootProject.findProperty(prop) ?: ""
+                String specific = rootProject.findProperty("${project.name}_${prop}") ?: ""
+
+                return (common.split(",") + specific.split(",") + [ primary ])
+                        .findAll { it != null }
+                        .findAll { it != "" }
+                        .collect { it.trim() }
+                        .unique()
             }
 
             artifact = tasks.remapJar

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -3,6 +3,7 @@ import net.fabricmc.loom.task.RemapJarTask
 
 plugins {
     id "com.github.johnrengelman.shadow"
+    id "com.hypherionmc.modutils.modpublisher"
 }
 
 def variants = rootProject.build_variants.split(',')
@@ -80,8 +81,8 @@ variants.each { variant ->
         remapJarTask = tasks.remapJar
         appendix = ""
     } else {
-        shadowJarTask = tasks.create("shadow${variant.capitalize()}Jar", ShadowJar)
-        remapJarTask = tasks.create("remap${variant.capitalize()}Jar", RemapJarTask)
+        shadowJarTask = tasks.maybeCreate("shadow${variant.capitalize()}Jar", ShadowJar)
+        remapJarTask = tasks.maybeCreate("remap${variant.capitalize()}Jar", RemapJarTask)
         appendix = variant
     }
 
@@ -123,15 +124,9 @@ components.java {
     }
 }
 
-publishing {
-    publications {
-        mavenFabric(MavenPublication) {
-            from components.java
-        }
-    }
-
-    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
-    repositories {
-        // Add repositories to publish to here.
+publisher {
+    [ curseDepends, modrinthDepends ].each {
+        it.required "fabric-api"
+        it.optional "modmenu"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,16 +24,19 @@ release_type=release
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
 minecraft_version=1.20.4
 parchment_version=1.20.2-2023.12.10
+supported_mc_versions=
 
 fabric_loader_version=0.15.3
 fabric_api_version=0.91.2+1.20.4
 fabric_loader_req=>=0.12.11
 fabric_mc_req=~1.20.4
+fabric_supported_mc_versions=
 
 neoforge_version=20.4.60-beta
 neoforge_mc_req=[1.20.4,)
 neoforge_loader_req=[1,)
 neoforge_req=[20,)
+neoforge_supported_mc_versions=
 
 # Other dependencies
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,8 @@ source_code_url=https://github.com/MinecraftFreecam/Freecam
 issue_tracker_url=https://github.com/MinecraftFreecam/Freecam/issues
 enabled_platforms=fabric,neoforge
 build_variants=normal,modrinth
+# release, beta or alpha. Used for publishMod task.
+release_type=release
 
 # Check versions on:
 # https://discord.architectury.dev

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -83,8 +83,8 @@ variants.each { variant ->
         remapJarTask = tasks.remapJar
         appendix = ""
     } else {
-        shadowJarTask = tasks.create("shadow${variant.capitalize()}Jar", ShadowJar)
-        remapJarTask = tasks.create("remap${variant.capitalize()}Jar", RemapJarTask)
+        shadowJarTask = tasks.maybeCreate("shadow${variant.capitalize()}Jar", ShadowJar)
+        remapJarTask = tasks.maybeCreate("remap${variant.capitalize()}Jar", RemapJarTask)
         appendix = variant
     }
 
@@ -126,18 +126,5 @@ variants.each { variant ->
 components.java {
     withVariantsFromConfiguration(project.configurations.shadowRuntimeElements) {
         skip()
-    }
-}
-
-publishing {
-    publications {
-        mavenForge(MavenPublication) {
-            from components.java
-        }
-    }
-
-    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
-    repositories {
-        // Add repositories to publish to here.
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
         maven { url "https://maven.fabricmc.net/" }
         maven { url "https://maven.architectury.dev/" }
         maven { url "https://maven.minecraftforge.net/" }
+        maven { url "https://maven.firstdark.dev/releases/" }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
# Mod publishing

This PR adds the [modpublisher plugin](https://github.com/firstdarkdev/modpublisher) which simplifies the process of publishing to [CurseForge](https://www.curseforge.com/) & [Modrinth](https://modrinth.com/).

For an overview, see [their readme](https://github.com/firstdarkdev/modpublisher/blob/2.0/readme.md) or their [full documentation](https://modpublisher.fdd-docs.com).

## Usage

After creating a release (setting version, release type, patching changelog, committing), you will use the `publish` task.

`publish` is Gradle's "umbrella" task, which depends on all publishing tasks. If you only want to publish to modding platforms, you can use `publishMod` instead, or even `publishCurseforge` & `publishModrinth` to publish only to Curseforge and Modrinth respectively.

Note there is also a `publishGitHub` task provided by modpublisher, however this will do nothing because we haven't configured modpublisher for GitHub Releases (see below). We can't disable the task (which would hide it) because `publishMod` depends on it.

## GitHub Releases

Publishing to GitHub is not covered by this PR. That may be better achieved as part of a CI/CD setup using GitHub Actions/Workflows.

[modpublisher](https://github.com/firstdarkdev/modpublisher) has built-in support for publishing GitHub releases, however for our use case the "version" would need to be different and we'll probably need more control...

## Secrets

API tokens/keys must be set to actually do any publishing. These can either be gradle properties (`curseforge_token` & `modrinth_token`) or environment variables (`CURSEFORGE_TOKEN` & `MODRINTH_TOKEN`).

Personally, I'd probably set these as "user" gradle properties by creating a `gradle.properties` file in the [`GRADLE_USER_HOME`](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home) directory (`~/.gradle` or `C:\Users\<USERNAME>\.gradle`). Setting up `.env` is another option.  
Definitely **do not** put them in the project gradle properties, as these get committed to git :joy:!

We'll also want these saved in the **repo secrets** if we ever setup a CI job to automate publishing.

## Published Jars

The appropriate jars are published to each platform; all platforms use the normal build variant (`remapJar`) except for Modrinth, which uses the output from `remapModrinthJar`.

## Changelog

I haven't added anything to the changelog as this PR only affects internal (dev-facing) stuff, which is already mentioned in the changelog.

The published release will contain the changelog entry relating to the current `mod_version`.

The changelog section header is omitted, because that _should_ be self-evident from the release the changelog is attached to, however this is configurable and could be included if desired.

## Alternative plugins

We initially explored using shedanial's [unified-publishing](https://github.com/shedaniel/unified-publishing), however we ran into an [issue](https://github.com/shedaniel/unified-publishing/issues/8) setting "embedded" related mods for the Modrinth platform. Seeing as everything we needed worked on  [modpublisher](https://github.com/firstdarkdev/modpublisher) & that project appears to be more actively maintained, we decided to use that instead.

### Original PR description
<details><summary>Hidden for brevity</summary>

This PR implements shedanial's [unified-publishing](https://github.com/shedaniel/unified-publishing) plugin to streamline the curseforge/modrinth publishing process.

Publishing to GitHub is not covered by this PR. That may be better achieved as part of a CI/CD setup using GitHub Actions/Workflows.  
That said, [modpublisher](https://github.com/firstdarkdev/modpublisher) has built-in support for publishing GitHub releases as part of a unified publish task, so we could consider using that instead.

API tokens/keys must be set to actually do any publishing. These can either be gradle properties (`curseforge_token` & `modrinth_token`) or environment variables (`CURSEFORGE_TOKEN` & `MODRINTH_TOKEN`).

Personally, I'd probably set these as "user" gradle properties by creating a `gradle.properties` file in the [`GRADLE_USER_HOME`](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home) directory (`~/.gradle` or `C:\Users\<USERNAME>\.gradle`). Setting up `.env` is another option.  
Definitely **do not** put them in the project gradle properties, as these get committed to git :joy:!

Run using `gradlew publishUnified`.

**I haven't tested this**, since I don't have access to your tokens. It's possible I've misinterpreted what is meant by "modrinth id"; currently it's set to `"freecam"`.

When testing, I'd recommend changing the `releaseType` to alpha and changing `mod_version` to something like `"TEST"`.

Come to think of it, `releaseType` should probably be set as in `gradle.properties`... Any other feedback, questions, etc welcome.

</details> 

Fixes #134 