### PR TITLE
Allow setting keybinds from Freecam's config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
+- Added a way to configure key bindings from Freecam's config menu ([#143](https://github.com/MinecraftFreecam/Freecam/pull/143)).
+
 ### Changed
 
 - Movement speed options now use sliders instead of text fields ([#190](https://github.com/MinecraftFreecam/Freecam/pull/190)).

--- a/common/src/main/java/net/xolt/freecam/config/ModConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModConfig.java
@@ -9,6 +9,7 @@ import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import me.shedaniel.clothconfig2.gui.entries.SelectionListEntry;
 import net.xolt.freecam.config.gui.AutoConfigExtensions;
 import net.xolt.freecam.config.gui.BoundedContinuous;
+import net.xolt.freecam.config.gui.ModBindingsConfig;
 import net.xolt.freecam.config.gui.VariantTooltip;
 import net.xolt.freecam.variant.api.BuildVariant;
 
@@ -22,6 +23,14 @@ public class ModConfig implements ConfigData {
         AutoConfig.register(ModConfig.class, JanksonConfigSerializer::new);
         AutoConfigExtensions.apply(ModConfig.class);
         INSTANCE = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
+    }
+
+    @ConfigEntry.Gui.Tooltip
+    @ConfigEntry.Gui.CollapsibleObject
+    public ControlsConfig controls = new ControlsConfig();
+    public static class ControlsConfig {
+        @ModBindingsConfig
+        private Object keys;
     }
 
     @ConfigEntry.Gui.Tooltip

--- a/common/src/main/java/net/xolt/freecam/config/gui/AutoConfigExtensions.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/AutoConfigExtensions.java
@@ -22,6 +22,7 @@ public class AutoConfigExtensions {
 
     public static void apply(Class<? extends ConfigData> configClass) {
         GuiRegistry registry = AutoConfig.getGuiRegistry(configClass);
+        ModBindingsConfigImpl.apply(registry);
         VariantTooltipImpl.apply(registry);
         BoundedContinuousImpl.apply(registry);
     }

--- a/common/src/main/java/net/xolt/freecam/config/gui/ModBindingsConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/ModBindingsConfig.java
@@ -1,0 +1,23 @@
+package net.xolt.freecam.config.gui;
+
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import me.shedaniel.clothconfig2.gui.entries.KeyCodeEntry;
+import net.xolt.freecam.config.ModBindings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Adds an {@link KeyCodeEntry entry} for each {@link ModBindings} to the annotated category.
+ * <p>
+ * This replaces whatever config entry GUIs would otherwise have been provided for the annotated field.
+ * <p>
+ * Can also be used together with {@link ConfigEntry.Gui.CollapsibleObject}, which places the entries in a collapsible
+ * sub-category. When used without {@link ConfigEntry.Gui.CollapsibleObject}, entries are added transitively at the same
+ * level as the annotated field.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ModBindingsConfig {}

--- a/common/src/main/java/net/xolt/freecam/config/gui/ModBindingsConfigImpl.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/ModBindingsConfigImpl.java
@@ -1,0 +1,51 @@
+package net.xolt.freecam.config.gui;
+
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
+import me.shedaniel.autoconfig.gui.registry.GuiRegistry;
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import me.shedaniel.clothconfig2.gui.entries.KeyCodeEntry;
+import me.shedaniel.clothconfig2.impl.builders.KeyCodeBuilder;
+import net.minecraft.network.chat.Component;
+import net.xolt.freecam.config.ModBindings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static net.xolt.freecam.config.gui.AutoConfigExtensions.ENTRY_BUILDER;
+
+class ModBindingsConfigImpl {
+
+    private ModBindingsConfigImpl() {}
+
+    static void apply(GuiRegistry registry) {
+
+        registry.registerAnnotationProvider(
+                (i18n, field, config, defaults, guiProvider) -> modBindingEntries(),
+                field -> !field.isAnnotationPresent(ConfigEntry.Gui.CollapsibleObject.class),
+                ModBindingsConfig.class
+        );
+
+        registry.registerAnnotationProvider(
+                (i18n, field, config, defaults, guiProvider) -> {
+                    ENTRY_BUILDER.startSubCategory(Component.translatable(i18n), modBindingEntries())
+                            .setExpanded(field.getDeclaredAnnotation(ConfigEntry.Gui.CollapsibleObject.class).startExpanded())
+                            .build();
+                    return new ArrayList<>(modBindingEntries());
+                },
+                field -> field.isAnnotationPresent(ConfigEntry.Gui.CollapsibleObject.class),
+                ModBindingsConfig.class
+        );
+    }
+
+    /**
+     * @return a {@link KeyCodeEntry} for each binding in {@link ModBindings}.
+     */
+    private static List<AbstractConfigListEntry> modBindingEntries() {
+        return ModBindings.stream()
+                .map(bind -> ENTRY_BUILDER.fillKeybindingField(Component.translatable(bind.getName()), bind))
+                .map(KeyCodeBuilder::build)
+                .map(AbstractConfigListEntry.class::cast)
+                .collect(Collectors.toList());
+    }
+}

--- a/common/src/main/resources/assets/freecam/lang/en_us.json
+++ b/common/src/main/resources/assets/freecam/lang/en_us.json
@@ -10,6 +10,8 @@
   "msg.freecam.closeTripod": "Closing camera %s",
   "msg.freecam.tripodReset": "Reset camera %s",
   "text.autoconfig.freecam.title": "Freecam Options",
+  "text.autoconfig.freecam.option.controls": "Key Bindings",
+  "text.autoconfig.freecam.option.controls.@Tooltip": "Freecam key bindings.",
   "text.autoconfig.freecam.option.movement": "Movement Options",
   "text.autoconfig.freecam.option.movement.@Tooltip": "How the camera moves.",
   "text.autoconfig.freecam.option.movement.flightMode": "Flight Mode",


### PR DESCRIPTION
## Goal

Allow users to configure everything from a single menu, if they prefer.

Keybinds are still present in the vanilla menu. This doesn't change how binds are stored/created/etc.

## Screenshot

![image](https://github.com/hashalite/Freecam/assets/5046562/a0428da7-6fa2-45f3-917e-4d64621099aa)

## Implementation

This PR adds a new `AddModBindings` annotation, implemented by `GuiTransformer`s that add a `KeyCodeEntry`, for each `ModBindings` value, to the annotated field.

This is accompanied by some minor refactoring/renaming.

## Movement

IMO, everything in **Movement** is somewhat _controls_ related. Perhaps the two categories should be combined?

Perhaps **Key binds** and **Movement** could be subcategories of **Controls**?

If **Movement** is moved or renamed, it'd be a good opportunity to scale up & convert the movement speeds to `int`, so they can be sliders instead of text fields. Otherwise users would keep their scaled-down values when upgrading.