### PR TITLE
DevLogin -> DevAuth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,14 +32,6 @@ subprojects {
                 // https://github.com/architectury/architectury-loom/blob/5b3e7c72b665f7eb38c23ceb677027acdc867398/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java#L117
                 configName "Run"
             }
-            loggedIn {
-                inherit client
-                configName "Run logged in"
-                programArg "--msa"
-                if (project.path.contains("forge")) {
-                    forgeTemplate "client"
-                }
-            }
             remove server // We only need client runs
         }
 
@@ -49,7 +41,6 @@ subprojects {
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings loom.officialMojangMappings()
-//        modLocalRuntime "com.ptsmods:devlogin:${rootProject.devlogin_version}"
     }
 }
 
@@ -78,6 +69,7 @@ allprojects {
         maven { url "https://maven.neoforged.net/releases/" }
         maven { url "https://maven.shedaniel.me/" }
         maven { url "https://maven.terraformersmc.com/" }
+        maven { url "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
     }
 
     // ensure that the encoding is set to UTF-8, no matter what the system default is

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -72,6 +72,7 @@ variants.each { variant ->
         }
     }
     run.source set
+    run.property "devauth.enabled", "false"
 
     loom.runs.create("${variant == "normal" ? "" : variant}LoggedInClient") {
         inherit run

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
 
+    modRuntimeOnly "me.djtheredstoner:DevAuth-fabric:${rootProject.devauth_version}"
+
     modImplementation ("com.terraformersmc:modmenu:${rootProject.modmenu_version}") {
         exclude module: "fabric-api"
     }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -73,6 +73,12 @@ variants.each { variant ->
     }
     run.source set
 
+    loom.runs.create("${variant == "normal" ? "" : variant}LoggedInClient") {
+        inherit run
+        configName += " (logged in)"
+        property "devauth.enabled", "true"
+    }
+
     // Configure/create jar tasks
     def shadowJarTask
     def remapJarTask

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,4 +36,4 @@ neoforge_req=[20,)
 # https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config?repo=architectury
 modmenu_version=9.0.0-pre.1
 cloth_version=13.0.114
-devlogin_version=3.4.1
+devauth_version=1.2.0

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -76,6 +76,13 @@ variants.each { variant ->
         dependency spi
     }
 
+    loom.runs.create("${variant == "normal" ? "" : variant}LoggedInClient") {
+        inherit run
+        forgeTemplate "client"
+        configName += " (logged in)"
+        property "devauth.enabled", "true"
+    }
+
     // Configure/create jar tasks
     def shadowJarTask
     def remapJarTask

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -67,6 +67,7 @@ variants.each { variant ->
         }
     }
     run.source set
+    run.property "devauth.enabled", "false"
 
     // Tell forge all this is part of one mod
     run.mods.register(rootProject.name) {

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -23,6 +23,8 @@ configurations {
 dependencies {
     neoForge "net.neoforged:neoforge:${rootProject.neoforge_version}"
 
+    modRuntimeOnly "me.djtheredstoner:DevAuth-neoforge:${rootProject.devauth_version}"
+
     modApi "me.shedaniel.cloth:cloth-config-neoforge:${rootProject.cloth_version}"
     include "me.shedaniel.cloth:cloth-config-neoforge:${rootProject.cloth_version}"
 


### PR DESCRIPTION
DevAuth has added neoforge support in their latest release, so I've ported from DevLogin.

`config.toml` is stored in `~/.config/devauth` or `C:\Users\<user>\.devauth`. You can have multiple accounts configured there.

You can also set `defaultEnabled = true` and dump the [devauth jar](https://github.com/DJtheRedstoner/DevAuth/releases) in `run/mods/` when debugging other projects, that way the project doesn't have to be configured to support devauth.

See the [configuration section](https://github.com/DJtheRedstoner/DevAuth#configuration) of their README for more detail.

You can copy IDE run configs and add `-Ddevauth.account=someaccount` if you have multiple accounts configured in your devauth config, for example.

Note: I've put this together on my laptop, which has an opengl issue meaning I can't test/run the game. Therefore **this PR is currently untested**.