### PR TITLE
Drop DevLogin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,14 +32,6 @@ subprojects {
                 // https://github.com/architectury/architectury-loom/blob/5b3e7c72b665f7eb38c23ceb677027acdc867398/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java#L117
                 configName "Run"
             }
-            loggedIn {
-                inherit client
-                configName "Run logged in"
-                programArg "--msa"
-                if (project.path.contains("forge")) {
-                    forgeTemplate "client"
-                }
-            }
             remove server // We only need client runs
         }
 
@@ -55,7 +47,6 @@ subprojects {
             officialMojangMappings()
             parchment("org.parchmentmc.data:parchment-${parchmentAppendix}:${parchmentVersion}@zip")
         }
-//        modLocalRuntime "com.ptsmods:devlogin:${rootProject.devlogin_version}"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,4 +38,3 @@ neoforge_req=[20,)
 # https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config?repo=architectury
 modmenu_version=9.0.0-pre.1
 cloth_version=13.0.114
-devlogin_version=3.4.1


### PR DESCRIPTION
This PR started off as just dropping DevLogin; as per [this comment](https://github.com/hashalite/Freecam/pull/147#issuecomment-1876462140), however I figured it'd be nice to document the ability to run logged in via DevAuth... `CONTRIBUTING.md` snowballed from there, although I've left it unfinished as it isn't the focus of this PR.

TBH most of the content should probably be replaced with links to external documentation. Having a wall of text covering stuff that most devs probably already know is only going to mask the useful info such as multi-platform & multi-variant info.

I'll let you decide if you'd rather merge with/without the documentation. You could just cherry-pick 98d13ef7b82a1accdb0d0911b41d1ea196f6ed1a into main.

If you like the idea of a CONTRIBUTING doc, but not this iteration, we can always look at it again in another PR. Alternatively, this could be the starting point and another PR could improve on it.

EDIT: removed the documentation for now.