### PR TITLE
Improve & generalise keybind code

### DIFF
--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -1,14 +1,15 @@
 package net.xolt.freecam;
 
-import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.CameraType;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.Input;
 import net.minecraft.client.player.KeyboardInput;
+import net.minecraft.client.renderer.texture.Tickable;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
+import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
 import net.xolt.freecam.tripod.TripodRegistry;
 import net.xolt.freecam.tripod.TripodSlot;
@@ -17,20 +18,15 @@ import net.xolt.freecam.util.FreecamPosition;
 import net.xolt.freecam.variant.api.BuildVariant;
 import org.jetbrains.annotations.Nullable;
 
-import static net.xolt.freecam.config.ModBindings.*;
-
 public class Freecam {
 
     public static final Minecraft MC = Minecraft.getInstance();
     public static final String MOD_ID = "freecam";
-    private static final long TOGGLE_KEY_MAX_TICKS = 10;
 
     private static boolean freecamEnabled = false;
     private static boolean tripodEnabled = false;
     private static boolean playerControlEnabled = false;
     private static boolean disableNextTick = false;
-    private static boolean toggleKeyUsedWhileHeld = false;
-    private static long toggleKeyHeldTicks = 0;
     private static final TripodRegistry tripods = new TripodRegistry();
     private static TripodSlot activeTripod = TripodSlot.NONE;
     private static FreeCamera freeCamera;
@@ -56,47 +52,7 @@ public class Freecam {
     }
 
     public static void postTick(Minecraft mc) {
-        if (KEY_TOGGLE.isDown()) {
-            // Count held ticks, so we can toggle on release
-            toggleKeyHeldTicks++;
-            KEY_TOGGLE.reset();
-
-            // Handle <toggle_key>+<hotbar_key> combos
-            for (KeyMapping combo : mc.options.keyHotbarSlots) {
-                while (combo.consumeClick()) {
-                    toggleTripod(TripodSlot.ofKeyCode(combo.getDefaultKey().getValue()));
-                    toggleKeyUsedWhileHeld = true;
-                }
-            }
-        }
-        // Check if toggle was pressed, and is now released
-        else if (KEY_TOGGLE.consumeClick() || toggleKeyHeldTicks > 0) {
-            // Only toggle if the key wasn't used (or held too long)
-            if (!toggleKeyUsedWhileHeld && toggleKeyHeldTicks < TOGGLE_KEY_MAX_TICKS) {
-                toggle();
-            }
-            // Reset state
-            KEY_TOGGLE.reset();
-            toggleKeyHeldTicks = 0;
-            toggleKeyUsedWhileHeld = false;
-        }
-
-        // Handle <reset_key>+<hotbar_key> combos
-        if (KEY_TRIPOD_RESET.isDown()) {
-            for (KeyMapping key : mc.options.keyHotbarSlots) {
-                while (key.consumeClick()) {
-                    resetCamera(TripodSlot.ofKeyCode(key.getDefaultKey().getValue()));
-                }
-            }
-        }
-
-        while (KEY_PLAYER_CONTROL.consumeClick()) {
-            switchControls();
-        }
-
-        while (KEY_CONFIG_GUI.consumeClick()) {
-            mc.setScreen(AutoConfig.getConfigScreen(ModConfig.class, mc.screen).get());
-        }
+        ModBindings.forEach(Tickable::tick);
     }
 
     public static void onDisconnect() {
@@ -104,6 +60,28 @@ public class Freecam {
             toggle();
         }
         tripods.clear();
+    }
+
+    public static boolean activateTripodHandler() {
+        boolean activated = false;
+        for (KeyMapping combo : MC.options.keyHotbarSlots) {
+            while (combo.consumeClick()) {
+                toggleTripod(TripodSlot.ofKeyCode(combo.getDefaultKey().getValue()));
+                activated = true;
+            }
+        }
+        return activated;
+    }
+
+    public static boolean resetTripodHandler() {
+        boolean reset = false;
+        for (KeyMapping key : MC.options.keyHotbarSlots) {
+            while (key.consumeClick()) {
+                resetCamera(TripodSlot.ofKeyCode(key.getDefaultKey().getValue()));
+                reset = true;
+            }
+        }
+        return reset;
     }
 
     public static void toggle() {

--- a/common/src/main/java/net/xolt/freecam/config/ModBindings.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModBindings.java
@@ -3,7 +3,6 @@ package net.xolt.freecam.config;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import me.shedaniel.autoconfig.AutoConfig;
-import net.minecraft.client.KeyMapping;
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.keys.FreecamKeyMapping;
 import org.jetbrains.annotations.NotNull;
@@ -39,29 +38,6 @@ public enum ModBindings {
 
     ModBindings(Supplier<FreecamKeyMapping> mappingSupplier) {
         lazyMapping = Suppliers.memoize(mappingSupplier);
-    }
-
-    /**
-     * @return the result of calling {@link KeyMapping#isDown()} on the represented {@link FreecamKeyMapping}.
-     * @see KeyMapping#isDown()
-     */
-    public boolean isDown() {
-        return get().isDown();
-    }
-
-    /**
-     * @return the result of calling {@link KeyMapping#consumeClick()} on the represented {@link FreecamKeyMapping}.
-     * @see KeyMapping#consumeClick()
-     */
-    public boolean consumeClick() {
-        return get().consumeClick();
-    }
-
-    /**
-     * Calls {@link FreecamKeyMapping#reset()} on the represented {@link FreecamKeyMapping}.
-     */
-    public void reset() {
-        get().reset();
     }
 
     /**

--- a/common/src/main/java/net/xolt/freecam/config/keys/FreecamComboKeyMapping.java
+++ b/common/src/main/java/net/xolt/freecam/config/keys/FreecamComboKeyMapping.java
@@ -1,0 +1,46 @@
+package net.xolt.freecam.config.keys;
+
+import com.mojang.blaze3d.platform.InputConstants;
+
+
+class FreecamComboKeyMapping extends FreecamKeyMapping {
+
+    private final Runnable action;
+    private final HoldAction holdAction;
+    private final long maxHoldTicks;
+
+    private boolean usedWhileHeld = false;
+    private long ticksHeld = 0;
+
+    FreecamComboKeyMapping(String translationKey, InputConstants.Type type, int code, Runnable action, HoldAction holdAction, long maxHoldTicks) {
+        super(translationKey, type, code);
+        this.action = action;
+        this.holdAction = holdAction;
+        this.maxHoldTicks = maxHoldTicks;
+    }
+
+    @Override
+    public void tick() {
+        if (isDown()) {
+            // Count held ticks, so we can run action on release
+            ticksHeld++;
+            reset();
+
+            // Handle combo actions
+            if (holdAction.run()) {
+                usedWhileHeld = true;
+            }
+        }
+        // Check if pressed, but now released
+        else if (consumeClick() || ticksHeld > 0) {
+            // Only run action if the key wasn't used (or held too long)
+            if (!usedWhileHeld && ticksHeld < maxHoldTicks) {
+                action.run();
+            }
+            // Reset state
+            reset();
+            ticksHeld = 0;
+            usedWhileHeld = false;
+        }
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/keys/FreecamKeyMapping.java
+++ b/common/src/main/java/net/xolt/freecam/config/keys/FreecamKeyMapping.java
@@ -1,0 +1,39 @@
+package net.xolt.freecam.config.keys;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.renderer.texture.Tickable;
+
+import java.util.function.Consumer;
+
+public class FreecamKeyMapping extends KeyMapping implements Tickable {
+
+    private final Consumer<FreecamKeyMapping> onTick;
+
+    /**
+     * @apiNote should only be used if overriding {@link #tick()}
+     */
+    protected FreecamKeyMapping(String translationKey, InputConstants.Type type, int code) {
+        this(translationKey, type, code, null);
+    }
+
+    FreecamKeyMapping(String translationKey, InputConstants.Type type, int code, Consumer<FreecamKeyMapping> onTick) {
+        super("key.freecam." + translationKey, type, code, "category.freecam.freecam");
+        this.onTick = onTick;
+    }
+
+    @Override
+    public void tick() {
+        onTick.accept(this);
+    }
+
+    /**
+     * Reset whether the key was pressed.
+     * <p>
+     * @implNote Cannot use {@link KeyMapping#release()} because it doesn't work as expected.
+     */
+    @SuppressWarnings("StatementWithEmptyBody")
+    public void reset() {
+        while (consumeClick()) {}
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/keys/FreecamKeyMappingBuilder.java
+++ b/common/src/main/java/net/xolt/freecam/config/keys/FreecamKeyMappingBuilder.java
@@ -1,0 +1,90 @@
+package net.xolt.freecam.config.keys;
+
+import com.mojang.blaze3d.platform.InputConstants;
+
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_UNKNOWN;
+
+public class FreecamKeyMappingBuilder {
+    private final String translationKey;
+    private InputConstants.Type type = InputConstants.Type.KEYSYM;
+    private int keyCode = GLFW_KEY_UNKNOWN;
+    private Runnable action;
+    private HoldAction holdAction;
+    private long maxTicks = 10;
+
+    private FreecamKeyMappingBuilder(String translationKey) {
+        this.translationKey = translationKey;
+    }
+
+    /**
+     * Start building a {@link FreecamKeyMapping key} with the translation key provided.
+     *
+     * @param translationKey key to be appended onto {@code "key.freecam."}
+     * @return a {@link FreecamKeyMapping} builder
+     */
+    public static FreecamKeyMappingBuilder builder(String translationKey) {
+        return new FreecamKeyMappingBuilder(translationKey);
+    }
+
+    public FreecamKeyMappingBuilder type(InputConstants.Type type) {
+        this.type = type;
+        return this;
+    }
+
+    public FreecamKeyMappingBuilder maxHoldTicks(long ticks) {
+        this.maxTicks = ticks;
+        return this;
+    }
+
+    public FreecamKeyMappingBuilder defaultKey(int keyCode) {
+        this.keyCode = keyCode;
+        return this;
+    }
+
+    public FreecamKeyMappingBuilder action(Runnable action) {
+        this.action = action;
+        return this;
+    }
+
+    public FreecamKeyMappingBuilder holdAction(HoldAction action) {
+        holdAction = action;
+        return this;
+    }
+
+    /**
+     * Build the {@link FreecamKeyMapping key mapping}.
+     * <p>
+     * If an {@link #action(Runnable) action} was defined, it will be run when the key is <strong>pressed</strong>.
+     * <p>
+     * If a {@link #holdAction(HoldAction) hold action} was defined, it will be run while the key is <strong>held</strong>
+     * (each tick).
+     * <p>
+     * If both were defined, a {@link FreecamComboKeyMapping combo key} is provided where the {@link #holdAction(HoldAction) hold action}
+     * is run as normal and the {@link #action(Runnable) action} is run when the key is <strong>released</strong>.
+     * <br>
+     * If the key was held for {@link #maxHoldTicks(long) max hold ticks} or longer (default 10) then {@link #action(Runnable) action}
+     * is <strong>not run</strong>. It is also not run if any {@link #holdAction(HoldAction) hold action} returned
+     * {@code true} since the key last released.
+     * @return the {@link FreecamKeyMapping keybind}.
+     */
+    public FreecamKeyMapping build() {
+        if (action != null && holdAction != null) {
+            return new FreecamComboKeyMapping(translationKey, type, keyCode, action, holdAction, maxTicks);
+        }
+        if (action != null) {
+            return new FreecamKeyMapping(translationKey, type, keyCode, self -> {
+                while (self.consumeClick()) {
+                    action.run();
+                }
+            });
+        }
+        if (holdAction != null) {
+            return new FreecamKeyMapping(translationKey, type, keyCode, self -> {
+                if (self.isDown()) {
+                    holdAction.run();
+                }
+            });
+        }
+        throw new IllegalStateException("No action defined.");
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/keys/HoldAction.java
+++ b/common/src/main/java/net/xolt/freecam/config/keys/HoldAction.java
@@ -1,0 +1,9 @@
+package net.xolt.freecam.config.keys;
+
+@FunctionalInterface
+public interface HoldAction {
+    /**
+     * @return whether the key was "used".
+     */
+    boolean run();
+}

--- a/common/src/main/java/net/xolt/freecam/mixins/MinecraftMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/MinecraftMixin.java
@@ -45,7 +45,7 @@ public class MinecraftMixin {
     // Prevents hotbar keys from changing selected slot when freecam key is held
     @Inject(method = "handleKeybinds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/KeyMapping;consumeClick()Z", ordinal = 2), cancellable = true)
     private void onHandleInputEvents(CallbackInfo ci) {
-        if (KEY_TOGGLE.isDown() || KEY_TRIPOD_RESET.isDown()) {
+        if (KEY_TOGGLE.get().isDown() || KEY_TRIPOD_RESET.get().isDown()) {
             ci.cancel();
         }
     }


### PR DESCRIPTION
Building on #126's `ModBindings` refactor & toggle key handling, this PR:

- Generalizes the "combo key" logic in `FreecamComboKeyMapping`
- Moves control over keybind handlers to the keybinds themselves
- Introduces a builder to make defining different types of keybinds more declarative.
- Reduce the amount of "key handling" in `Freecam` to `activateTripodHandler()` & `resetTripodHandler()`,

I also removed `ModBinding`'s "wrapper" methods;  
They only existed to make using the enum values _prettier_, that is now unnecessary because the keybinds to define their own logic & don't care about the enum.  
The one exception to this is in `MinecraftMixin`, however a couple `.get()`s is worth the reduced complexity/maintenance IMO.  
If you disagree, then 00a5b7392f4bd826d50b7ab6c59495a58f56c676 can be dropped or reverted easily.

This PR does not affect the existing behavior in any way.