### PR TITLE
Drop scheduled runs for Crowdin Download Translations CI

### DIFF
--- a/.github/workflows/crowdin-download-translations.yaml
+++ b/.github/workflows/crowdin-download-translations.yaml
@@ -1,10 +1,9 @@
 name: Crowdin (Download Translations)
 
+# Allow running manually,
+# including triggering via webhooks
 on:
-  workflow_dispatch: # Allow running manually
-  schedule:
-    # https://crontab.guru
-    - cron: '0 */12 * * *' # Every 12 hours
+  workflow_dispatch:
 
 # Queue this workflow after others in the 'crowdin' group, to avoid concurrency issues.
 concurrency:


### PR DESCRIPTION
Webhook is done, so we can drop scheduled runs for Download Translations