### PR TITLE
Fix CurseForge JavaVersion for Java 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ subprojects {
             versionType = rootProject.release_type
             curseEnvironment = "client"
             loaders = [ project.name ]
-            javaVersions = ["Java ${project.java.targetCompatibility}"]
+            javaVersions = ["Java ${project.java.targetCompatibility.getMajorVersion()}"]
 
             // Get the changelog entry using the changelog plugin
             changelog = provider {


### PR DESCRIPTION
Using `JavaVersion.toString()` returns `"1.8"` for `JAVA_1_8`, however modpublisher expects `"Java 8"`.

We can instead use `JavaVersion.getMajorVersion()`.

I've tested this using following gradle snippet:

```gradle
JavaVersion.values().each {
  logger.warn "Java ${it} - ${it.getMajorVersion()}"
}
```
Which outputs the following logs:

<details><summary>Log</summary>
<p>

```
Java 1.1 - 1
Java 1.2 - 2
Java 1.3 - 3
Java 1.4 - 4
Java 1.5 - 5
Java 1.6 - 6
Java 1.7 - 7
Java 1.8 - 8
Java 9 - 9
Java 10 - 10
Java 11 - 11
Java 12 - 12
Java 13 - 13
Java 14 - 14
Java 15 - 15
Java 16 - 16
Java 17 - 17
Java 18 - 18
Java 19 - 19
Java 20 - 20
Java 21 - 21
Java 22 - 22
Java 23 - 23
Java 24 - 24
Java 25 - 25
Java 26 - 26
```

</p>
</details> 