### PR TITLE
Create issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -1,0 +1,96 @@
+name: Bug report
+description: Report something not working as expected
+labels: ["bug", "unverified"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Please check if an issue already exists
+
+        You can use the search box on our [issues page](https://github.com/MinecraftFreecam/Freecam/issues). Ensure you check both open issues as well as closed issues.
+
+        If you find the bug has already been reported, you can:
+        - **Subscribe** for updates on the issue
+        - **React** "👍" to show your interest
+        - Or **comment** if you have extra details to add
+
+        ----
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the issue
+      placeholder: e.g. Nothing happens when I press the toggle key (`F4`)...
+      description: What happens?
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      placeholder: e.g. I expected Freecam to activate when pressing `F4`...
+      description: What did you expect to happen instead?
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the issue
+      value: |
+        1. Open a singleplayer world
+        2. Enable Freecam by pressing `F4`
+        3. ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output
+      placeholder: Logs may help us to identify the issue
+      description: You can find logs in `.minecfaft/logs/latest.log`
+      render: shell
+  - type: textarea
+    id: crash-report
+    attributes:
+      label: Crash report
+      placeholder: If the game crashes, include your crash-report
+      description: You may find reports in `.minecfaft/crash-reports/crash-<date+time>-client.txt`
+      render: shell
+  - type: input
+    id: prevalence
+    attributes:
+      label: How prevalent is the issue?
+      description: How often do you or others encounter this issue?
+      placeholder: e.g. every time I press the key
+  - type: input
+    id: mod-version
+    attributes:
+      label: Freecam version
+      placeholder: 1.2.3
+      description: What version of Freecam are you usign?
+    validations:
+      required: true
+  - type: dropdown
+    id: modrinth
+    attributes:
+      label: Are you using "Modrinth Edition"?
+      description: Modrinth Edition has some additional restrictions, e.g. it will not allowing you to clip through blocks unless you are `op`, in creative, or in singleplayer.
+      options: [ "Yes", "No" ]
+      default: 1
+    validations:
+      required: true
+  - type: input
+    id: mc-version
+    attributes:
+      label: Minecraft version
+      placeholder: 1.20.4
+      description: What version of Minecraft are you using?
+    validations:
+      required: true
+  - type: checkboxes
+    id: mod-platform
+    attributes:
+      label: Modding platform
+      description: Select the platform(s) you've seen this issue on
+      options:
+        - label: Fabric
+        - label: Neoforge
+        - label: Forge
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yaml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a new feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Please check if an issue already exists
+
+        You can use the search box on our [issues page](https://github.com/MinecraftFreecam/Freecam/issues). Ensure you check both open issues as well as closed issues.
+
+        If you find your idea has already been suggested, you can:
+        - **Subscribe** for updates on the issue
+        - **React** "👍" to show your interest
+        - Or **comment** if you have extra details to add
+
+        ----
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of the feature
+      description: |
+        What is your idea and how should it work?
+
+        The more detail you provide, the more likely we'll understand your idea and be able to implemnt it.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this useful?
+      description: What problem does it solve? How would it help you?
+  - type: input
+    id: mod-version
+    attributes:
+      label: Freecam version
+      placeholder: 1.2.3
+      description: What version of Freecam are you currently using?
+    validations:
+      required: true
+  

--- a/.github/ISSUE_TEMPLATE/3-language.yaml
+++ b/.github/ISSUE_TEMPLATE/3-language.yaml
@@ -1,0 +1,37 @@
+name: New Language
+description: Request we enable a new language in Crowdin
+title: "[New Language]: "
+labels: ["i18n"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Language name
+      placeholder: English (US)
+    validations:
+      required: true
+  - type: input
+    id: locale
+    attributes:
+      label: Locale code
+      placeholder: en_us
+      description: You can find a list of Minecraft locale codes [here](https://minecraft.wiki/w/Language#Languages).
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please don't request we enable a language if you don't intend to help translate it.
+
+        If you're unfamiliar with Crowdin, you can read their [getting started as a volunteer translator guide](https://support.crowdin.com/enterprise/getting-started-for-volunteers).
+  - type: checkboxes
+    id: already-enabled
+    attributes:
+      label: Please check if the language is already enabled
+      description: |
+        Before opening this request, please check that we don't already target your language on our [Crowdin project](https://crowdin.com/project/freecam).
+
+        If we do, you can use Crowdin to submit new translations or propose changes.
+      options:
+        - label: I have checked this language isn't enabled on Crowdin
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Translations
+      url: https://crowdin.com/project/freecam
+      about: You can help improve Freecam's translations using Crowdin.
+    - name: Questions and discussion
+      url: https://github.com/MinecraftFreecam/Freecam/discussions/new/choose
+      about: If the options above don't seem right, you may be better off starting a "discussion" instead.


### PR DESCRIPTION
This PR adds [GitHub issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) with the goal of guiding users in creating useful & actionable issues.

I've got this [merged on my fork](https://github.com/MattSturgeon/Freecam/issues/new/choose), so you can play around with the forms and/or create test issues there. I'll try and keep my fork's main branch in sync with this PR for testing purposes.

I'm open to a lot of feedback on this; it's definitely not easy to strike the balance between cultivating a useful issue and overwhelming end-users with too many questions.  
Alternatively, we can merge this more-or-less as-is and then iterate over time.