### PR TITLE
Version bumping task & CI

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,86 @@
+name: Bump project version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version level to be bumped
+        required: true
+        default: minor
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+#      pre:
+#        description: 'pre-release version'
+#        required: false
+#        type: string
+
+# Only allow running one build job at a time to optimise cache hits
+concurrency:
+  group: builds
+
+# Grant GITHUB_TOKEN write access
+permissions:
+  contents: write
+
+env:
+  # sed expression to strip whitespace from property keys
+  # will not match comment lines
+  # prints result, so use with -n
+  replace_key_whitespace: 's/^\s*\([^=#][^=]*\)\s*=\s*/\1=/p'
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: microsoft
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Get current metadata
+        id: old_props
+        run: sed -ne "$replace_key_whitespace" gradle.properties >> $GITHUB_OUTPUT
+
+      - name: Bump version
+        run: ./gradlew bumpVersion --${{ inputs.bump }}
+
+      - name: Bump changelog
+        run: ./gradlew patchChangelog
+
+      - name: Get updated metadata
+        id: new_props
+        run: sed -ne "$replace_key_whitespace" gradle.properties >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        id: commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Bump version to ${{ steps.new_props.outputs.mod_version }}
+
+      - name: Summarize
+        run: |
+          version="${{ steps.new_props.outputs.mod_version }}"
+          old="${{ steps.old_props.outputs.mod_version }}"
+          sha="${{ steps.commit.outputs.commit_hash }}"
+          url="${{ github.server_url }}/${{ github.repository }}/commit/$sha"
+          
+          echo "## Summary" >> $GITHUB_STEP_SUMMARY
+          echo "Version was bumped from \`$old\` to \`$version\`." >> $GITHUB_STEP_SUMMARY
+          echo >> $GITHUB_STEP_SUMMARY
+          
+          if [[ -z "$sha" ]]; then
+            echo "**Error**: Nothing to commit!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "[\`${sha:0:6}\`]($url) pushed to \`${{ github.ref_name }}\`." >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo >> $GITHUB_STEP_SUMMARY
+          

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import net.fabricmc.loom.task.RemapJarTask
+import net.xolt.freecam.gradle.BumpVersionTask
 import org.jetbrains.changelog.Changelog
+import org.jetbrains.changelog.tasks.BaseChangelogTask
 
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
@@ -12,6 +14,18 @@ plugins {
 tasks.named('wrapper') {
     // Use "all" so we get sources and javadoc too
     distributionType = "all"
+}
+
+// Helper task that bumps the version number
+tasks.register("bumpVersion", BumpVersionTask) {
+    group = "version"
+    input = file("gradle.properties")
+    key = "mod_version"
+}
+
+// Move the changelog tasks to the "version" group
+tasks.withType(BaseChangelogTask).configureEach {
+    group = "version"
 }
 
 // Don't need these on the root project

--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,9 @@ architectury {
 }
 
 changelog {
-    // Use the mod_version in gradle.properties as the release version/tag,
-    // without any prefix such as "v".
+    // Use the mod_version in gradle.properties as the release version/tag.
     // Build tag/diff links using the github repo URL.
     version = project.mod_version
-    versionPrefix = ""
     repositoryUrl = project.source_code_url
 
     // Title & intro are printed right at the start of the changelog.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+}
+
+repositories {
+    mavenCentral()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/buildSrc/src/main/kotlin/net/xolt/freecam/gradle/BumpVersionTask.kt
+++ b/buildSrc/src/main/kotlin/net/xolt/freecam/gradle/BumpVersionTask.kt
@@ -1,0 +1,131 @@
+package net.xolt.freecam.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.kotlin.dsl.property
+import java.io.File
+import javax.inject.Inject
+import kotlin.math.max
+import kotlin.text.Regex.Companion.escape
+
+/**
+ * Bump a version property in a properties file
+ */
+abstract class BumpVersionTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+
+    @get:Input
+    @get:Option(option = "major", description = "Increment the major version")
+    val major = objects.property<Boolean>().convention(false)
+
+    @get:Input
+    @get:Option(option = "minor", description = "Increment the minor version")
+    val minor = objects.property<Boolean>().convention(false)
+
+    @get:Input
+    @get:Option(option = "patch", description = "Increment the patch version")
+    val patch = objects.property<Boolean>().convention(false)
+
+    /**
+     * The property key containing the version to bump
+     */
+    @get:Input
+    val key = objects.property<String>().convention("version")
+
+    /**
+     * The `gradle.properties` file
+     */
+    @get:InputFile
+    abstract val input: RegularFileProperty
+
+    /**
+     * Run by Gradle when executing implementing tasks.
+     */
+    @TaskAction
+    fun run() {
+        val file = input.asFile.get()
+        logger.info("Updating ${file.path}")
+        update(file)
+    }
+
+    private fun update(file: File) {
+        // Regex matches `key` and captures both the value and any formatting
+        val keyRegex = """^(\s*${escape(key.get())}\s*=\s*)(.*?)$""".toRegex()
+
+        // Read all lines, replacing any that match the key regex
+        val lines = file.readLines().map {
+            it.replace(keyRegex) { match ->
+                val left = match.groupValues[1]
+                val v = match.groupValues[2]
+
+                if (v.isEmpty()) {
+                    logger.warn("Assuming empty version assigned to ${key.get()} is \"0\"")
+                    left + bump("0")
+                } else {
+                    left + bump(v)
+                }
+            }
+        }
+
+        // Write the updated lines
+        // FIXME trailing empty line at EOF is removed...
+        file.writeText(lines.joinToString("\n"))
+    }
+
+    private fun bump(version: String): String {
+        // Split the integer parts
+        val v = version.split('.').map(String::toInt).toMutableList()
+
+        logger.info("Bumping version \"$version\" with ${v.size} parts...")
+
+        if (major.get()) {
+            logger.info("- Bumping major version")
+            v.bump(0)
+        }
+
+        if (minor.get()) {
+            logger.info("- Bumping minor version")
+            v.bump(1)
+        }
+
+        if (patch.get()) {
+            logger.info("- Bumping patch version")
+            v.bump(2)
+        }
+
+        // TODO support pre-release versions
+
+        val new = v.joinToString(".")
+        logger.info("- New version: $new")
+        return new
+    }
+
+    // Increment the given index, adding new entries if necessary
+    private fun MutableList<Int>.bump(index: Int) {
+        val min = index + 1
+        val max = max(3, min)
+
+        // Ensure the version is long enough to bump this part
+        while (size < min) {
+            add(0)
+        }
+
+        // Do the thing!
+        this[index]++
+
+        // Cap version size (semver uses 3 parts)
+        while (size > max) {
+            removeLast()
+        }
+
+        // Reset lesser version parts to zero
+        // E.g. reset `patch` when bumping `minor`
+        for (i in min until size) {
+            this[i] = 0
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a version bumping gradle task, and a CI workflow that makes use of it.

[This workflow run](https://github.com/MattSturgeon/Freecam/actions/runs/8493999134) on my fork demonstrates the CI job working and [this commit](https://github.com/MattSturgeon/Freecam/commit/be81d3c80010f5226a0b9733320ffd56593b80a1) was pushed as a result.

### But, why?

Well, GitHub's branch protection prevents non-admins from pushing directly to a branch. This means I wouldn't be able to prepare a release commit (bumping version & changelog) without making a PR and getting it reviewed.

Luckily, branch protection doesn't apply to CI, so we can work around this by creating a workflow that is manually triggered (`workflow_dispatch`).

### Bonus

As a bonus, this gives all maintainers (even admins) a simple & unified way to do the mundane task of prepping a release's metadata.

We can also use `workflow_dispatch` to configure inputs, such as which version "level" is to be bumped.

![image](https://github.com/MinecraftFreecam/Freecam/assets/5046562/6d4d5b7a-0653-4a66-a26f-8d66bb9e0b93)

### Future work

I'd like to add additional workflows that are triggered when tags get pushed.

One workflow for "primary" tags, which will simply un-draft the matching release:

```shell
gh release edit "${{ github.ref_name }}" --draft=false
```

And another that will trigger for "`+mc`" tags, that publish to github, cusrseforge & modrinth, using modpublisher.

Once https://github.com/firstdarkdev/modpublisher/pull/11 is done, the github release can be published as a draft, which means the tag doesn't need to exist.

Maybe it would also make sense for the bump-version workflow to create a tag, but for now I think tagging should be manual :thinking: 

### Also

While testing I noticed we didn't update the changelog config for the new `v` tag prefix. That is fixed by this PR.

