### PR TITLE
Add a "build" CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,75 @@
+name: Build
+
+on:
+  push:
+
+# Only allow running one build job at a time to optimise cache hits
+concurrency:
+  group: builds
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Calculate metadata
+        id: data
+        run: |
+          # Calculate data
+          full="${{ github.sha }}"
+          short="${full:0:6}"
+          date="$(date --utc +'%Y-%m-%d_%H-%M-%S')"
+          forge="$(grep --max-count=1 --only-matching --word-regexp '\(neo\)\?forge' gradle.properties)"
+          minecraft="$(sed -ne 's/^\s*minecraft_version\s*=\s*\(.*\)$/\1/p' gradle.properties)"
+
+          # Print to output
+          echo "full_sha=$full" >> $GITHUB_OUTPUT
+          echo "short_sha=$short" >> $GITHUB_OUTPUT
+          echo "date=$date" >> $GITHUB_OUTPUT
+          echo "forge_name=$forge" >> $GITHUB_OUTPUT
+          echo "minecraft=$minecraft" >> $GITHUB_OUTPUT
+          echo "name_suffix=${date}-${short}-mc${minecraft}" >> $GITHUB_OUTPUT
+
+          # Print to stdout too
+          echo Metadata:
+          cat $GITHUB_OUTPUT
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: microsoft
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build
+        run: ./gradlew build
+
+        # Upload separately, or they'll be zipped together
+      - name: Upload all builds
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-builds-${{ steps.data.outputs.name_suffix }}.zip
+          path: build/libs
+          retention-days: 30
+          if-no-files-found: error
+      - name: Upload Fabric build
+        uses: actions/upload-artifact@v4
+        with:
+          name: freecam-fabric-${{ steps.data.outputs.name_suffix }}.jar
+          path: |
+            build/libs/*-fabric-*.jar
+            !**-modrinth-*.jar
+          retention-days: 90
+          if-no-files-found: error
+      - name: Upload Forge build
+        uses: actions/upload-artifact@v4
+        with:
+          name: freecam-${{ steps.data.outputs.forge_name }}-${{ steps.data.outputs.name_suffix }}.jar
+          path: |
+            build/libs/*-${{ steps.data.outputs.forge_name }}-*.jar
+            !**-modrinth-*.jar
+          retention-days: 90
+          if-no-files-found: error


### PR DESCRIPTION
This PR adds a CI workflow that builds every commit pushed (including to PRs) and uploads the jars as artifacts.

No reason to wait for #153 to get some basics like this :smiley: 

This PR's own CI job [successfully ran here](https://github.com/MinecraftFreecam/Freecam/actions/runs/8530290526).