### PR TITLE
Add GitHub publishing and CI publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,44 @@
+# This CI Workflow builds any tags pushed,
+# and releases them to a (draft) GitHub release, CurseForge, & Modrinth.
+name: Publish Release Build
+
+on:
+  push:
+    # tags should be in a release branch
+    branches:
+      - 'main'
+      - '1.*' # e.g. 1.20
+    tags:
+      - 'v*\+mc*' # e.g. v1.2.3+mc1.20.4
+
+# Only allow running one build job at a time to optimise cache hits
+concurrency:
+  group: builds
+
+# Grant permission to create/update releases
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: microsoft
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+        # TODO assert tag matches project version
+        # TODO cache build output between jobs/workflows
+
+      - name: Build & publish
+        run: ./gradlew publishMod
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN || '' }}
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN || '' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,69 @@
+# This CI workflow marks the draft release as "published".
+# If there is no draft yet the run will fail (and can be re-run later)
+name: Publish GitHub Release
+
+on:
+  push:
+    # Only release tags on the main branch
+    branches:
+      - 'main'
+    tags:
+      - 'v*' # e.g. v1.2.3
+      - '!v*\+mc*' # exclude tags handled by publish.yaml
+
+# Only allow running one build job at a time to optimise cache hits
+concurrency:
+  group: builds
+
+# Grant permission to create/update releases
+permissions:
+  contents: write
+
+env:
+  TAG: ${{ github.ref_name }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check release exists
+        run: |
+          # Lookup a release using this tag:
+          # Print stdout to `response` and stderr to `errors`
+          if gh api /repos/{owner}/{repo}/releases/tags/"$TAG" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              1> response 2> errors
+          then
+            # API request returned OK, double check the response's tag_name
+            if [[ "$(jq '.tag_name' < response)" == "$TAG" ]]; then
+              # Found a release:
+              echo "Found a release with a tag_name matching \"$TAG\""
+            else
+              echo "Error: response returned the wrong tag!" >& 2
+              cat response >& 2
+              exit 2
+            fi
+          else
+            # Double check we got a "Not Found" response
+            msg="$(jq '.message' < response)"
+            if [[ "$msg" == "Not Found" ]]; then
+              echo "Release not found for \"$TAG\""
+              exit 1
+            else
+              echo "Error getting GitHub Release:" >& 2
+              [[ -n "$msg" ]] && echo "Error: $msg"
+              cat errors >& 2
+              exit 2
+            fi
+          fi
+
+        # Publish the release by setting draft=false
+        # Also ensure the release title is correct
+      - name: Publish release
+        run: |
+          gh release edit "$TAG" \
+            --title="Freecam ${TAG#v}" \
+            --draft="false"

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,17 @@ subprojects {
             curseID = "557076"
             modrinthID = "XeEZ3fK2"
 
+            github {
+                // Extract our repo slug from the github URL
+                repo = rootProject.source_code_url.replaceFirst("^https?://github\\.com/", "")
+                // GitHub releases must be associated with a git tag
+                // We want this to be the canonical tag, not the annotated build tag
+                tag = "v${rootProject.mod_version}"
+                // Create a draft release, so that GitHub doesn't actually create the tag
+                // does not affect already published releases
+                draft = true
+            }
+
             // Format display name, e.g. "1.2.4 for MC 1.20.4 (fabric)"
             displayName = "${rootProject.mod_version} for MC ${rootProject.minecraft_version} (${project.name})"
             version = project.version
@@ -209,10 +220,11 @@ subprojects {
 
             def dummy = "default"
             apiKeys {
+                github findProperty("github_token") ?: System.getenv("GITHUB_TOKEN") ?: System.getenv("GH_TOKEN") ?: dummy
                 curseforge findProperty("curseforge_token") ?: System.getenv("CURSEFORGE_TOKEN") ?: dummy
                 modrinth findProperty("modrinth_token") ?: System.getenv("MODRINTH_TOKEN") ?: dummy
             }
-            debug = [ apiKeys.curseforge, apiKeys.modrinth ].contains dummy
+            debug = [ apiKeys.github, apiKeys.curseforge, apiKeys.modrinth ].contains dummy
         }
 
         tasks.publish.dependsOn tasks.publishMod

--- a/build.gradle
+++ b/build.gradle
@@ -218,13 +218,14 @@ subprojects {
                 it.embedded "cloth-config"
             }
 
-            def dummy = "default"
+            def ci = System.getenv("CI") != null
+            def dummy = ci ? "" : "default"
             apiKeys {
                 github findProperty("github_token") ?: System.getenv("GITHUB_TOKEN") ?: System.getenv("GH_TOKEN") ?: dummy
                 curseforge findProperty("curseforge_token") ?: System.getenv("CURSEFORGE_TOKEN") ?: dummy
                 modrinth findProperty("modrinth_token") ?: System.getenv("MODRINTH_TOKEN") ?: dummy
             }
-            debug = [ apiKeys.github, apiKeys.curseforge, apiKeys.modrinth ].contains dummy
+            debug = !ci
         }
 
         tasks.publish.dependsOn tasks.publishMod

--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ subprojects {
             versionType = rootProject.release_type
             curseEnvironment = "client"
             loaders = [ project.name ]
-            javaVersions = ["Java ${project.java.targetCompatibility.getMajorVersion()}"]
+            javaVersions = [ project.java.targetCompatibility ]
 
             // Get the changelog entry using the changelog plugin
             changelog = provider {


### PR DESCRIPTION
## Summary

This PR consists of three parts:

#### 1. Configure modpublisher for GitHub Releases

Some recent Modpublisher PRs added support for configuring the github release tag separately from the "version". This allows use to use `1.2.3+mc1.20.4` as our curseforge/modrinth version, while publishing to a GitHub Release tagged as `v1.2.3`.

Support for marking the Release as "draft" was also added. This has the advantage of allowing a release to be created _before_ the tag exists, without GitHub automatically creating an (unsigned) tag.

Now, running `./gradlew publishMod` will also publish a draft release to GitHub.

Currently untested.

#### 2. Auto publish when pushing `+mc*` tags

This is pretty simple; automatically run `./gradlew publishMod` whenever a tag ending in `+mc*` is pushed to one of the release branches (`main` and `1.*`).

Currently untested.

#### 3. Publish GH releases when pushing "canonical" tags

This is still WIP, and may be postponed until a follow up PR.

The concept is simple; set `draft=false` on the github release when a "release tag" gets pushed.

However, we may also want to create the release if it doesn't exist yet? Alternatively, we might want a new modpublisher feature where the release is marked `draft` only if the tag doesn't exist yet. https://github.com/firstdarkdev/modpublisher/issues/16

Currently WIP & untested.

## Extra notes

See [Filter pattern cheat sheet](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), because it turns out the `on` tag/branch/path filters aren't actually globs. It's some weird custom mash-up of regex & glob...