### PR TITLE
Declare main classes API status

### DIFF
--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -17,6 +17,7 @@ import net.xolt.freecam.tripod.TripodSlot;
 import net.xolt.freecam.util.FreeCamera;
 import net.xolt.freecam.util.FreecamPosition;
 import net.xolt.freecam.variant.api.BuildVariant;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 public class Freecam {
@@ -33,6 +34,7 @@ public class Freecam {
     private static FreeCamera freeCamera;
     private static CameraType rememberedF5 = null;
 
+    @ApiStatus.Internal
     public static void preTick(Minecraft mc) {
         // Disable if the previous tick asked us to,
         // or Freecam is restricted on the current server
@@ -53,10 +55,12 @@ public class Freecam {
         }
     }
 
+    @ApiStatus.Internal
     public static void postTick(Minecraft mc) {
         ModBindings.forEach(Tickable::tick);
     }
 
+    @ApiStatus.Internal
     public static void onDisconnect() {
         if (isEnabled()) {
             toggle();
@@ -64,6 +68,7 @@ public class Freecam {
         tripods.clear();
     }
 
+    @ApiStatus.Internal
     public static boolean activateTripodHandler() {
         boolean activated = false;
         for (KeyMapping combo : MC.options.keyHotbarSlots) {
@@ -75,6 +80,7 @@ public class Freecam {
         return activated;
     }
 
+    @ApiStatus.Internal
     public static boolean resetTripodHandler() {
         boolean reset = false;
         for (KeyMapping key : MC.options.keyHotbarSlots) {
@@ -86,6 +92,7 @@ public class Freecam {
         return reset;
     }
 
+    @ApiStatus.AvailableSince("0.3.1")
     public static void toggle() {
         if (isRestrictedOnServer()) {
             if (ModConfig.INSTANCE.notification.notifyFreecam) {
@@ -142,6 +149,7 @@ public class Freecam {
         }
     }
 
+    @ApiStatus.AvailableSince("1.1.8")
     public static void switchControls() {
         if (!isEnabled()) {
             return;
@@ -263,6 +271,8 @@ public class Freecam {
         }
     }
 
+    @ApiStatus.Experimental
+    @ApiStatus.AvailableSince("1.2.3")
     public static void moveToEntity(@Nullable Entity entity) {
         if (freeCamera == null) {
             return;
@@ -274,6 +284,8 @@ public class Freecam {
         freeCamera.copyPosition(entity);
     }
 
+    @ApiStatus.Experimental
+    @ApiStatus.AvailableSince("1.2.3")
     public static void moveToPosition(@Nullable FreecamPosition position) {
         if (freeCamera == null) {
             return;
@@ -285,6 +297,8 @@ public class Freecam {
         freeCamera.applyPosition(position);
     }
 
+    @ApiStatus.Experimental
+    @ApiStatus.AvailableSince("1.2.3")
     public static void moveToPlayer() {
         if (freeCamera == null) {
             return;
@@ -296,22 +310,29 @@ public class Freecam {
         );
     }
 
+    @ApiStatus.AvailableSince("0.4.0")
     public static FreeCamera getFreeCamera() {
         return freeCamera;
     }
 
+    @ApiStatus.AvailableSince("1.2.3")
     public static void disableNextTick() {
         disableNextTick = true;
     }
 
+    @ApiStatus.AvailableSince("0.2.2")
     public static boolean isEnabled() {
         return freecamEnabled || tripodEnabled;
     }
 
+    @ApiStatus.Experimental
+    @ApiStatus.AvailableSince("1.0.0")
     public static boolean isPlayerControlEnabled() {
         return playerControlEnabled;
     }
 
+    @ApiStatus.Experimental
+    @ApiStatus.AvailableSince("1.2.4")
     public static boolean isRestrictedOnServer() {
         ServerData server = MC.getCurrentServer();
         ModConfig.ServerRestriction mode = ModConfig.INSTANCE.servers.mode;

--- a/common/src/main/java/net/xolt/freecam/util/FreeCamera.java
+++ b/common/src/main/java/net/xolt/freecam/util/FreeCamera.java
@@ -18,12 +18,15 @@ import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
 import net.xolt.freecam.config.ModConfig;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
 import java.util.UUID;
 
 import static net.xolt.freecam.Freecam.MC;
 
+@ApiStatus.Internal
+@ApiStatus.AvailableSince("0.4.0")
 public class FreeCamera extends LocalPlayer {
 
     private static final ClientPacketListener NETWORK_HANDLER = new ClientPacketListener(


### PR DESCRIPTION
Turns out mods integrating with or attempting to be compatible with Freecam may wish to compile against our classes and use our API.

e.g. FirstPersonModel [compiles against](https://github.com/tr7zw/FirstPersonModel/blob/1760a72e724d2cf7325c13485e487b699af02dcb/gradle-compose.yml#L20) Freecam v1.1.6 and uses the public API `Freecam.isEnabled()` that has (luckily) remained ABI compatible since before our initial commit.

It may be useful to explicitly state the API status of various public methods, even if for no reason other than to make us think twice before changing the public API.

I've only done this for the _main_ classes, `Freecam` and `FreeCamera` for now. Ideally, we'd declare the API status of all public classes.

One method I could only trace back to v0.2.2, which is the oldest release on GitHub and pre-dates the initial commit (AFAICT).