### PR TITLE
Bump modpublisher to 2.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import org.jetbrains.changelog.tasks.BaseChangelogTask
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
     id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
-    id "com.hypherionmc.modutils.modpublisher" version "2.0.5" apply false
+    id "com.hypherionmc.modutils.modpublisher" version "2.1.2" apply false
     id "com.github.johnrengelman.shadow" version "8.1.1" apply false
     id "org.jetbrains.changelog" version "2.2.0"
 }


### PR DESCRIPTION
Fixes Neoforge support, see [changelog](https://github.com/firstdarkdev/modpublisher/blob/dev/changelog.md)