### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Avoid duplicate runs when both `push` and `pull_request` are triggered:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+  pull_request:
 
 # Only allow running one build job at a time to optimise cache hits
 concurrency:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -66,6 +66,11 @@ jobs:
           # We need to commit as a user to ensure CI is run on the commit
           # We need to push as an admin/owner to bypass branch-protection
           token: ${{ secrets.HASHALITE_PAT }}
+          # Ensure we commit as a bot, since we can't reliably get an author slug from `github.actor`
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_author: ${{ github.actor }} <41898282+github-actions[bot]@users.noreply.github.com>
+          # The commit message, specify the new version
           commit_message: Bump version to ${{ steps.new_props.outputs.mod_version }}
 
       - name: Summarize

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -21,9 +21,9 @@ on:
 concurrency:
   group: builds
 
-# Grant GITHUB_TOKEN write access
+# GITHUB_TOKEN only needs read access because we'll use a PAT to push
 permissions:
-  contents: write
+  contents: read
 
 env:
   # sed expression to strip whitespace from property keys
@@ -63,6 +63,9 @@ jobs:
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          # We need to commit as a user to ensure CI is run on the commit
+          # We need to push as an admin/owner to bypass branch-protection
+          token: ${{ secrets.HASHALITE_PAT }}
           commit_message: Bump version to ${{ steps.new_props.outputs.mod_version }}
 
       - name: Summarize


### PR DESCRIPTION
- **Enable `build` CI on PRs**
This should make the build workflow run on PRs too, as originally intended.\
It may end up running twice when pushing to PRs on non-fork branches though...

- **Use owner's PAT in bump-version CI**
To bypass branch protection, we can use a Personal Access Token generated on @hashalite's account. Should be added to the repo secrets as "`HASHALITE_PAT`".

- **Ensure bump-version commits as a bot**
This is the default anyway for the _committer_, but for _author_ [stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action) uses the last commit's author, which may or may not be the same as the CI's triggerer (`github.actor`).