### PR TITLE
Fix initial publishing CI bugs

### DIFF
--- a/.github/workflows/crowdin-upload-sources.yaml
+++ b/.github/workflows/crowdin-upload-sources.yaml
@@ -3,8 +3,6 @@ name: Crowdin (Upload Sources)
 on:
   workflow_dispatch: # Allow running manually
   push: # Run when en_us is modified on the main branch
-    branches:
-      - main
     paths:
       - '**/lang/en_us.json'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: microsoft
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,6 @@ name: Publish GitHub Release
 
 on:
   push:
-    # Only release tags on the main branch
-    branches:
-      - 'main'
     tags:
       - 'v*' # e.g. v1.2.3
       - '!v*\+mc*' # exclude tags handled by publish.yaml


### PR DESCRIPTION
I'm sure this won't be the last, but here's fixes for the first bugs we've found in the new CI added in #195

- **fix(ci): only run publish workflows on tag pushes**
- **fix(ci): java version should be 21**
