### PR TITLE
Port to Minecraft 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
+- 1.21 Support ([#222](https://github.com/MinecraftFreecam/Freecam/pull/222)).
 - 1.20.6 Support ([#223](https://github.com/MinecraftFreecam/Freecam/pull/223)).
 
 ### Changed

--- a/common/src/main/java/net/xolt/freecam/util/FreeCamera.java
+++ b/common/src/main/java/net/xolt/freecam/util/FreeCamera.java
@@ -9,6 +9,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.protocol.Packet;
+import net.minecraft.server.ServerLinks;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -33,16 +34,30 @@ public class FreeCamera extends LocalPlayer {
             MC,
             MC.getConnection().getConnection(),
             new CommonListenerCookie(
+                    // localGameProfile
                     new GameProfile(UUID.randomUUID(), "FreeCamera"),
+                    // worldSessionTelemetryManager
                     MC.getTelemetryManager().createWorldSessionManager(false, null, null),
+                    // receivedRegistries
                     RegistryAccess.Frozen.EMPTY,
+                    // enabledFeatures
                     FeatureFlagSet.of(),
+                    // serverBrand
                     null,
+                    // serverData
                     MC.getCurrentServer(),
+                    // postDisconnectScreen
                     MC.screen,
+                    // serverCookies
                     Collections.emptyMap(),
+                    // chatState
                     MC.gui.getChat().storeState(),
-                    false)) {
+                    // strictErrorHandling
+                    false,
+                    // customReportDetails
+                    Collections.emptyMap(),
+                    // serverLinks
+                    ServerLinks.EMPTY)) {
         @Override
         public void send(Packet<?> packet) {
         }

--- a/fabric/src/main/java/net/xolt/freecam/fabric/mixins/LevelRendererMixin.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/mixins/LevelRendererMixin.java
@@ -2,6 +2,7 @@ package net.xolt.freecam.fabric.mixins;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.util.profiling.ProfilerFiller;
@@ -27,12 +28,11 @@ public abstract class LevelRendererMixin {
 
     @Shadow @Final private RenderBuffers renderBuffers;
 
-    @Shadow private void renderEntity(Entity entity, double cameraX, double cameraY, double cameraZ, float tickDelta, PoseStack matrices, MultiBufferSource vertexConsumers) {}
+    @Shadow protected abstract void renderEntity(Entity entity, double camX, double camY, double camZ, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource);
 
     // Makes the player render if showPlayer is enabled.
     @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;checkPoseStack(Lcom/mojang/blaze3d/vertex/PoseStack;)V", ordinal = 0), locals = CAPTURE_FAILHARD)
-    private void onRender(float partialTick,
-                          long nanoTime,
+    private void onRender(DeltaTracker deltaTracker,
                           boolean renderBlockOutline,
                           Camera camera,
                           GameRenderer gameRenderer,
@@ -40,8 +40,9 @@ public abstract class LevelRendererMixin {
                           Matrix4f matrix4f,
                           Matrix4f matrix4f2,
                           CallbackInfo ci,
+                          // Local capture needed for poseStack
                           TickRateManager tickRateManager,
-                          float g,
+                          float partialTick,
                           ProfilerFiller profilerFiller,
                           Vec3 cameraPosition,
                           double x,

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,25 +26,25 @@ release_type=release
 # https://maven.parchmentmc.org/org/parchmentmc/data
 # Forge dependencies use maven's version range spec:
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
-minecraft_version=1.20.6
+minecraft_version=1.21
 parchment_version=1.20.6-2024.06.02
 supported_mc_versions=
 
 fabric_loader_version=0.15.11
-fabric_api_version=0.100.0+1.20.6
-fabric_loader_req=>=0.12.11
-fabric_mc_req=~1.20.5
-fabric_supported_mc_versions=1.20.5
+fabric_api_version=0.100.1+1.21
+fabric_loader_req=>=0.14.0
+fabric_mc_req=>1.21-
+fabric_supported_mc_versions=
 
-neoforge_version=20.6.116
+neoforge_version=21.0.0-beta
 neoforge_pr=
-neoforge_mc_req=[1.20.6,)
+neoforge_mc_req=[1.21,)
 neoforge_loader_req=[1,)
-neoforge_req=[20.6.11-beta,)
+neoforge_req=[21.0.0-beta,)
 neoforge_supported_mc_versions=
 
 # Other dependencies
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu
 # https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config?repo=architectury
-modmenu_version=10.0.0-beta.1
-cloth_version=14.0.126
+modmenu_version=11.0.0-beta.1
+cloth_version=15.0.127


### PR DESCRIPTION
## Overview

Builds ok, loads into singleplayer and freecam can be activated. I've not yet tested anything beyond that.

I had to add back your show player fix that was reverted when we switched to neoforge. To quote their changelog:

> - `20.6.4-beta` Render local player when the `renderViewEntity` is not the local player
>   neoforged/NeoForge#858

Other than that, very minimal changes needed again :smile: 

Maybe we should merge this, do a "pre-release" and watch for feedback? It'd be interesting to see if the build/publish/release CI works and is able to support `-beta` versions (`1.2.5-beta1+mc1.21` I guess?)

## Testing

You can find pre-built jars on the [CI workflow summary](https://github.com/MinecraftFreecam/Freecam/actions/runs/9506570912).