### PR TITLE
Port to 1.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
+- 1.20.6 Support ([#223](https://github.com/MinecraftFreecam/Freecam/pull/223)).
+
 ### Changed
 
 ### Removed

--- a/common/src/main/resources/freecam-common.mixins.json
+++ b/common/src/main/resources/freecam-common.mixins.json
@@ -14,7 +14,6 @@
     "GameRendererMixin",
     "GuiMixin",
     "ItemInHandRendererMixin",
-    "LevelRendererMixin",
     "LightTextureMixin",
     "LivingEntityMixin",
     "LocalPlayerMixin",

--- a/fabric/src/main/java/net/xolt/freecam/fabric/mixins/LevelRendererMixin.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/mixins/LevelRendererMixin.java
@@ -1,4 +1,4 @@
-package net.xolt.freecam.mixins;
+package net.xolt.freecam.fabric.mixins;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;

--- a/fabric/src/main/resources/freecam-fabric.mixins.json
+++ b/fabric/src/main/resources/freecam-fabric.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
+    "LevelRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,25 +26,25 @@ release_type=release
 # https://maven.parchmentmc.org/org/parchmentmc/data
 # Forge dependencies use maven's version range spec:
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
-minecraft_version=1.20.5
-parchment_version=1.20.4-2024.02.25
+minecraft_version=1.20.6
+parchment_version=1.20.6-2024.06.02
 supported_mc_versions=
 
-fabric_loader_version=0.15.10
-fabric_api_version=0.97.6+1.20.5
+fabric_loader_version=0.15.11
+fabric_api_version=0.100.0+1.20.6
 fabric_loader_req=>=0.12.11
-fabric_mc_req=>1.20.4
-fabric_supported_mc_versions=
+fabric_mc_req=~1.20.5
+fabric_supported_mc_versions=1.20.5
 
-neoforge_version=20.5.0-beta
+neoforge_version=20.6.116
 neoforge_pr=
-neoforge_mc_req=[1.20.5,)
+neoforge_mc_req=[1.20.6,)
 neoforge_loader_req=[1,)
-neoforge_req=[20.5.0-beta,)
+neoforge_req=[20.6.11-beta,)
 neoforge_supported_mc_versions=
 
 # Other dependencies
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu
 # https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config?repo=architectury
-modmenu_version=10.0.0-alpha.3
-cloth_version=14.0.125
+modmenu_version=10.0.0-beta.1
+cloth_version=14.0.126

--- a/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
@@ -5,13 +5,13 @@ import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.ModLoadingContext;
-import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
-import net.neoforged.neoforge.event.TickEvent;
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
@@ -21,14 +21,15 @@ import net.xolt.freecam.config.ModConfig;
 @SuppressWarnings("unused")
 public class FreecamForge {
 
+    public FreecamForge(ModContainer container) {
+        // Register our config screen with Forge
+        container.registerExtensionPoint(IConfigScreenFactory.class, (client, parent) ->
+                AutoConfig.getConfigScreen(ModConfig.class, parent).get());
+    }
+
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event) {
         ModConfig.init();
-
-        // Register our config screen with Forge
-        ModLoadingContext.get().registerExtensionPoint(IConfigScreenFactory.class, () -> (client, parent) ->
-                AutoConfig.getConfigScreen(ModConfig.class, parent).get()
-        );
     }
 
     @SubscribeEvent
@@ -39,12 +40,12 @@ public class FreecamForge {
     @EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
     public static class GlobalEventHandler {
         @SubscribeEvent(priority = EventPriority.HIGH)
-        public static void onTick(TickEvent.ClientTickEvent event) {
-            final Minecraft client = Minecraft.getInstance();
-            switch (event.phase) {
-                case START -> Freecam.preTick(client);
-                case END -> Freecam.postTick(client);
-            }
+        public static void preTick(ClientTickEvent.Pre event) {
+            Freecam.preTick(Minecraft.getInstance());
+        }
+        @SubscribeEvent(priority = EventPriority.HIGH)
+        public static void postTick(ClientTickEvent.Post event) {
+            Freecam.postTick(Minecraft.getInstance());
         }
     }
 }

--- a/neoforge/src/main/java/net/xolt/freecam/forge/mixins/LevelRendererMixin.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/mixins/LevelRendererMixin.java
@@ -1,0 +1,27 @@
+package net.xolt.freecam.forge.mixins;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.Entity;
+import net.xolt.freecam.Freecam;
+import net.xolt.freecam.config.ModConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static net.xolt.freecam.Freecam.MC;
+
+@Mixin(LevelRenderer.class)
+public class LevelRendererMixin {
+
+    // Disable player rendering if show player is disabled
+    // (non-camera LocalPlayers are rendered by default on Forge)
+    @Inject(method = "renderEntity", at = @At("HEAD"), cancellable = true)
+    private void onRenderEntity(Entity entity, double x, double y, double z, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, CallbackInfo ci) {
+        if (entity == MC.player && Freecam.isEnabled() && !ModConfig.INSTANCE.visual.showPlayer) {
+            ci.cancel();
+        }
+    }
+}

--- a/neoforge/src/main/resources/freecam-neoforge.mixins.json
+++ b/neoforge/src/main/resources/freecam-neoforge.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
+    "LevelRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Many of the changes in #222 also applied to the Neoforge version of 1.20.6, because NF 20.6 contained a couple breaking changes that affected us.

I've marked the fabric build as compatible with 1.20.5, though I've not tested that.

IMO this should be merged first, followed by branching off 1.20.6, rebasing #222 to remove redundant changes, and then merging that too.
