### PR TITLE
Another round of CI fixes

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -37,11 +37,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Set git's auth to use the owner's Personal Access Token:
+          # We need to commit as a user to ensure CI is run on the commit
+          # We need to push as an admin/owner to bypass branch-protection
+          token: ${{ secrets.HASHALITE_PAT }}
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: microsoft
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
@@ -63,9 +70,6 @@ jobs:
         id: commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          # We need to commit as a user to ensure CI is run on the commit
-          # We need to push as an admin/owner to bypass branch-protection
-          token: ${{ secrets.HASHALITE_PAT }}
           # Ensure we commit as a bot, since we can't reliably get an author slug from `github.actor`
           commit_user_name: github-actions[bot]
           commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ permissions:
 
 env:
   TAG: ${{ github.ref_name }}
+  REPO: ${{ github.repository }}
 
 jobs:
   release:
@@ -29,7 +30,7 @@ jobs:
         run: |
           # Lookup a release using this tag:
           # Print stdout to `response` and stderr to `errors`
-          if gh api /repos/{owner}/{repo}/releases/tags/"$TAG" \
+          if gh api /repos/"$REPO"/releases/tags/"$TAG" \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               1> response 2> errors

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ changelog {
 
     // Regex used to find versions in headings.
     // The default regex only supports semantic versions, this one is more lenient.
-    headerParserRegex = ~/(\d+(?:\.\d+)+)/
+    headerParserRegex = ~/(\d+(?:\.\d+)+(?:-[-a-z]+\d*)?)/
 }
 
 allprojects {


### PR DESCRIPTION
### ci/release: fix `gh` repo placeholders
Can't use `{owner}` or `{repo}` placeholders when there's no git repo checked out. We can just use the `github.repository` [context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) from GH Actions though.

### ci/bump-version: fix PAT
`token` should be passed to the checkout action; this will setup git config to use the PAT. The git-auto-commit-action action will just use git's config, rather than any inputs/variables.

### changelog: support pre-release version suffexes
E.g. version tags ending in `-beta1` should now be supported by the `headerParserRegex`. You can [test the regex here](https://regex101.com/r/MZOobE/1).

I opted to keep it simple, rather than cover all edge-cases. Feel free to propose changes though.

The regex is used by the changelog gradle plugin when looking for version headers in the changelog file, e.g. to know where to cut the unreleased section when doing a version bump, or to know which section to use when printing a changelog to modpublisher release notes.

----

Fixes #224
