### PR TITLE
refactor: introduce a `DummyInput` wrapper

### DIFF
--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -14,6 +14,7 @@ import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
 import net.xolt.freecam.tripod.TripodRegistry;
 import net.xolt.freecam.tripod.TripodSlot;
+import net.xolt.freecam.util.DummyInput;
 import net.xolt.freecam.util.FreeCamera;
 import net.xolt.freecam.util.FreecamPosition;
 import net.xolt.freecam.variant.api.BuildVariant;
@@ -46,9 +47,8 @@ public class Freecam {
         if (isEnabled()) {
             // Prevent player from being controlled when freecam is enabled
             if (mc.player != null && mc.player.input instanceof KeyboardInput && !isPlayerControlEnabled()) {
-                Input input = new Input();
-                input.shiftKeyDown = mc.player.input.shiftKeyDown; // Makes player continue to sneak after freecam is enabled.
-                mc.player.input = input;
+                // Makes player continue to sneak after freecam is enabled.
+                mc.player.input = new DummyInput(mc.player.input);
             }
 
             mc.gameRenderer.setRenderHand(ModConfig.INSTANCE.visual.showHand);
@@ -155,13 +155,14 @@ public class Freecam {
             return;
         }
 
+        playerControlEnabled = !playerControlEnabled;
         if (playerControlEnabled) {
-            freeCamera.input = new KeyboardInput(MC.options);
-        } else {
             MC.player.input = new KeyboardInput(MC.options);
             freeCamera.input = new Input();
+        } else {
+            freeCamera.input = new KeyboardInput(MC.options);
+            // We set MC.player.input every tick anyway, so don't bother here
         }
-        playerControlEnabled = !playerControlEnabled;
     }
 
     private static void onEnableTripod(TripodSlot tripod) {

--- a/common/src/main/java/net/xolt/freecam/util/DummyInput.java
+++ b/common/src/main/java/net/xolt/freecam/util/DummyInput.java
@@ -1,0 +1,15 @@
+package net.xolt.freecam.util;
+
+import net.minecraft.client.player.Input;
+
+public class DummyInput extends Input {
+
+    public DummyInput(Input old) {
+        this(old.shiftKeyDown);
+    }
+
+    public DummyInput(boolean isSneaking) {
+        // Makes player continue to sneak after freecam is enabled.
+        this.shiftKeyDown = isSneaking;
+    }
+}


### PR DESCRIPTION
`DummyInput` can be used to provide an empty `Input` instance that remembers some state from a previous `Input` instance.

This small refactor adds a `DummyInput` class that extends `Input` and takes over the responsibility for persisting the player's "is sneaking" state when the player is not actively being controlled.

- This shifts some responsibility away from the main `Freecam` class.
- This will make persisting additional state (jump, sprint?) easier.
- This will make porting to 1.21.3 easier, as the `Input` class has been refactored upstream.

Currently only sneak is persisted. In the future we may decide to persist additional state, such as sprint or jump.
