### PR TITLE
build: bump modpublisher & parchment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import org.jetbrains.changelog.tasks.BaseChangelogTask
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
     id "dev.architectury.loom" version "1.7-SNAPSHOT" apply false
-    id "com.hypherionmc.modutils.modpublisher" version "2.1.2" apply false
+    id "com.hypherionmc.modutils.modpublisher" version "2.1.7+snapshot.0" apply false
     id "com.github.johnrengelman.shadow" version "8.1.1" apply false
     id "org.jetbrains.changelog" version "2.2.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ release_type=release
 # Forge dependencies use maven's version range spec:
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
 minecraft_version=1.21.3
-parchment_version=1.21-2024.07.07
+parchment_version=1.21.1-2024.11.17
 supported_mc_versions=1.21.2
 
 fabric_loader_version=0.16.7

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ pluginManagement {
         maven { url "https://maven.architectury.dev/" }
         maven { url "https://maven.minecraftforge.net/" }
         maven { url "https://maven.firstdark.dev/releases/" }
+        maven { url "https://maven.firstdark.dev/snapshots/" }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
- **build(parchment): 2024.07.07 -> 2024.11.17**
- **build(modpublisher): 2.1.2 -> 2.1.7** (snapshot)
  - for https://github.com/firstdarkdev/modpublisher/pull/26
