### PR TITLE
refactor: autoconfig -> cloth-config

### DIFF
--- a/common/src/main/java/net/xolt/freecam/config/CollisionBehavior.java
+++ b/common/src/main/java/net/xolt/freecam/config/CollisionBehavior.java
@@ -48,7 +48,14 @@ public class CollisionBehavior {
         return false;
     }
 
+    // Autoconfig implementation
     static InteractionResult onConfigChange(ConfigHolder<ModConfig> holder, ModConfig config) {
+        onConfigChange(config);
+        return InteractionResult.PASS;
+    }
+
+    // General implementation
+    public static void onConfigChange(ModConfig config) {
         String[] ids = config.collision.whitelist.ids.stream()
                 .map(id -> id.contains(":") ? id : "minecraft:" + id)
                 .toArray(String[]::new);
@@ -61,8 +68,6 @@ public class CollisionBehavior {
                 .matching(ids)
                 .matching(patterns)
                 .build();
-
-        return InteractionResult.PASS;
     }
 
     private static String getBlockId(Block block) {

--- a/common/src/main/java/net/xolt/freecam/config/ConfigSerializer.java
+++ b/common/src/main/java/net/xolt/freecam/config/ConfigSerializer.java
@@ -1,0 +1,8 @@
+package net.xolt.freecam.config;
+
+public interface ConfigSerializer<T> {
+
+    void serialize(T config) throws Exception;
+
+    T deserialize() throws Exception;
+}

--- a/common/src/main/java/net/xolt/freecam/config/JsonConfigSerializer.java
+++ b/common/src/main/java/net/xolt/freecam/config/JsonConfigSerializer.java
@@ -1,0 +1,59 @@
+package net.xolt.freecam.config;
+
+// FIXME: add our own jankson dependency
+// and/or use a different json/config library
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Jankson;
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.JsonObject;
+import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedWriter;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class JsonConfigSerializer<T> implements ConfigSerializer<T> {
+
+    private final Class<T> configClass;
+    private final String name;
+    private final Path filepath;
+    private final Jankson jankson;
+
+    public JsonConfigSerializer(Class<T> configClass, String name) {
+        this(configClass, name, Jankson.builder().build());
+    }
+
+    public JsonConfigSerializer(Class<T> configClass, String name, Jankson jankson) {
+        this.configClass = configClass;
+        this.name = name;
+        this.jankson = jankson;
+        // TODO: consider whether this should be hard-coded or configurable...
+        this.filepath = Minecraft.getInstance().gameDirectory
+                .toPath()
+                .resolve("config")
+                .resolve(name + ".json5");
+    }
+
+    @Override
+    public void serialize(T config) throws Exception {
+        Files.createDirectories(filepath.getParent());
+        BufferedWriter writer = Files.newBufferedWriter(filepath);
+        String json = jankson.toJson(config).toJson(true, true);
+        writer.write(json);
+        writer.close();
+    }
+
+    @Override
+    public @Nullable T deserialize() throws Exception {
+        // Return an "default" instance if no config file exists
+        if (!Files.exists(filepath)) {
+            return configClass.getConstructor().newInstance();
+        }
+
+        // Deserialize the file to an instance of config class
+        InputStream stream = Files.newInputStream(filepath);
+        JsonObject json = jankson.load(stream);
+        stream.close();
+        return jankson.fromJson(json, configClass);
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/ModConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModConfig.java
@@ -8,6 +8,7 @@ import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.autoconfig.annotation.ConfigEntry.Gui.EnumHandler.EnumDisplayOption;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import me.shedaniel.clothconfig2.gui.entries.SelectionListEntry;
+import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.gui.AutoConfigExtensions;
 import net.xolt.freecam.config.gui.ValidateRegex;
 import net.xolt.freecam.config.gui.BoundedContinuous;
@@ -21,6 +22,11 @@ import java.util.List;
 
 @Config(name = "freecam")
 public class ModConfig implements ConfigData {
+
+    // Additional to autoconfig's serializer, here's one we can use with our NewConfig
+    @ConfigEntry.Gui.Excluded
+    static final JsonConfigSerializer<ModConfig> NEW_SERIALIZER =
+            new JsonConfigSerializer<>(ModConfig.class, Freecam.MOD_ID);
 
     @ConfigEntry.Gui.Excluded
     public static final ModConfig DEFAULTS = new ModConfig();

--- a/common/src/main/java/net/xolt/freecam/config/ModConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModConfig.java
@@ -23,6 +23,9 @@ import java.util.List;
 public class ModConfig implements ConfigData {
 
     @ConfigEntry.Gui.Excluded
+    public static final ModConfig DEFAULTS = new ModConfig();
+
+    @ConfigEntry.Gui.Excluded
     public static ModConfig INSTANCE;
 
     public static void init() {

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -15,6 +15,7 @@ import net.xolt.freecam.config.gui.DoubleSliderEntry;
 import net.xolt.freecam.variant.api.BuildVariant;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -105,6 +106,7 @@ public class NewConfig {
                         ModConfig.FlightMode.class,
                         ModConfig.FlightMode.DEFAULT) // FIXME load from a real config
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.movement.flightMode.@Tooltip"))
+                .setDefaultValue(ModConfig.FlightMode.DEFAULT) // FIXME load from a config API
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -115,7 +117,7 @@ public class NewConfig {
                 10,
                 1, // FIXME load from config
                 Component.translatable("text.cloth-config.reset_value"),
-                () -> 1.0,
+                () -> 1.0, // TODO get from config system
                 val -> { } // TODO save to config
 
         );
@@ -130,7 +132,7 @@ public class NewConfig {
                 10,
                 1, // FIXME load from config
                 Component.translatable("text.cloth-config.reset_value"),
-                () -> 1.0,
+                () -> 1.0, // TODO get from config system
                 val -> { } // TODO save to config
 
         );
@@ -158,11 +160,13 @@ public class NewConfig {
 
         BooleanListEntry ignoreTransparent = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent"), false)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent.@Tooltip"))
+                .setDefaultValue(false) // TODO get from config system
                 // .setSaveConsumer() // TODO
                 .build();
 
         BooleanListEntry ignoreOpenable = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable"), false)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable.@Tooltip"))
+                .setDefaultValue(false) // TODO get from config
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -173,6 +177,7 @@ public class NewConfig {
         }
         BooleanListEntry ignoreCustom = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom"), !BuildVariant.getInstance().name().equals("modrinth"))
                 .setTooltip(ignoreCustomTooltip.toArray(Component[]::new))
+                .setDefaultValue(!BuildVariant.getInstance().name().equals("modrinth")) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -180,6 +185,7 @@ public class NewConfig {
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[1]"))
+                .setDefaultValue(Collections.emptyList())
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -187,6 +193,7 @@ public class NewConfig {
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[1]"))
+                .setDefaultValue(Collections.emptyList())
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -198,6 +205,7 @@ public class NewConfig {
         }
         BooleanListEntry ignoreAll = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll"), !BuildVariant.getInstance().name().equals("modrinth"))
                 .setTooltip(ignoreAllTooltip.toArray(Component[]::new))
+                .setDefaultValue(!BuildVariant.getInstance().name().equals("modrinth")) // TODO get from config system
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -205,6 +213,7 @@ public class NewConfig {
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck.@Tooltip[1]"))
+                .setDefaultValue(false) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -235,26 +244,31 @@ public class NewConfig {
                         ModConfig.Perspective.class,
                         ModConfig.Perspective.INSIDE) // FIXME load from a real config
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.perspective.@Tooltip"))
+                .setDefaultValue(ModConfig.Perspective.INSIDE) // TODO get from config system
                 // .setSaveConsumer() // TODO
                 .build();
 
         BooleanListEntry showPlayer = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showPlayer"), true)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showPlayer.@Tooltip"))
+                .setDefaultValue(true) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         BooleanListEntry showHand = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showHand"), false)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showHand.@Tooltip"))
+                .setDefaultValue(false) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         BooleanListEntry fullBright = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.fullBright"), false)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.fullBright.@Tooltip"))
+                .setDefaultValue(false) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         BooleanListEntry showSubmersion = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion"), false)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion.@Tooltip"))
+                .setDefaultValue(false) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -280,6 +294,7 @@ public class NewConfig {
 
         BooleanListEntry disableOnDamage = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage"), true)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage.@Tooltip"))
+                .setDefaultValue(true) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -292,6 +307,7 @@ public class NewConfig {
                                 : "text.autoconfig.freecam.option.utility.freezePlayer.@Tooltip[1]"
                         )
                 )
+                .setDefaultValue(false) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -303,6 +319,7 @@ public class NewConfig {
         }
         BooleanListEntry allowInteract = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract"), false)
                 .setTooltip(allowInteractTooltip.toArray(Component[]::new))
+                .setDefaultValue(false) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -311,6 +328,7 @@ public class NewConfig {
                         ModConfig.InteractionMode.class,
                         ModConfig.InteractionMode.CAMERA) // FIXME load from a real config
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.interactionMode.@Tooltip"))
+                .setDefaultValue(ModConfig.InteractionMode.CAMERA) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -340,16 +358,19 @@ public class NewConfig {
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.servers.mode.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.servers.mode.@Tooltip[1]"))
+                .setDefaultValue(ModConfig.ServerRestriction.NONE) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         StringListListEntry whitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.whitelist"), new ArrayList<>())
                 // .setTooltip()
+                .setDefaultValue(Collections.emptyList()) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         StringListListEntry blacklist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.blacklist"), new ArrayList<>())
                 // .setTooltip()
+                .setDefaultValue(Collections.emptyList()) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
@@ -373,11 +394,13 @@ public class NewConfig {
 
         BooleanListEntry notifyFreecam = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam"), true)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam.@Tooltip"))
+                .setDefaultValue(true) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         BooleanListEntry notifyTripod = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod"), true)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod.@Tooltip"))
+                .setDefaultValue(true) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -118,34 +118,27 @@ public class NewConfig {
                 .setSaveConsumer(value -> ModConfig.INSTANCE.movement.flightMode = value)
                 .build();
 
-        DoubleSliderEntry horizontalSpeed = new DoubleSliderEntry(
-                Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed"),
-                2,
-                0,
-                10,
-                ModConfig.INSTANCE.movement.horizontalSpeed,
-                Component.translatable("text.cloth-config.reset_value"),
-                () -> ModConfig.DEFAULTS.movement.horizontalSpeed,
-                value -> ModConfig.INSTANCE.movement.horizontalSpeed = value
-        );
-        horizontalSpeed.setTooltipSupplier(() -> Optional.of(new Component[]{
-                Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed.@Tooltip")
-        }));
+        DoubleSliderEntry horizontalSpeed = DoubleSliderEntry.builder(
+                        Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed"),
+                        entryBuilder.getResetButtonKey())
+                .setPrecision(2)
+                .setMax(10)
+                .setValue(ModConfig.INSTANCE.movement.horizontalSpeed)
+                .setDefaultValue(() -> ModConfig.DEFAULTS.movement.horizontalSpeed)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.movement.horizontalSpeed = value)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed.@Tooltip"))
+                .build();
 
-        DoubleSliderEntry verticalSpeed = new DoubleSliderEntry(
-                Component.translatable("text.autoconfig.freecam.option.movement.verticalSpeed"),
-                2,
-                0,
-                10,
-                ModConfig.INSTANCE.movement.verticalSpeed,
-                Component.translatable("text.cloth-config.reset_value"),
-                () -> ModConfig.DEFAULTS.movement.verticalSpeed,
-                value -> ModConfig.INSTANCE.movement.verticalSpeed = value
-
-        );
-        verticalSpeed.setTooltipSupplier(() -> Optional.of(new Component[]{
-                Component.translatable("text.autoconfig.freecam.option.movement.verticalSpeed.@Tooltip")
-        }));
+        DoubleSliderEntry verticalSpeed = DoubleSliderEntry.builder(
+                        Component.translatable("text.autoconfig.freecam.option.movement.verticalSpeed"),
+                        entryBuilder.getResetButtonKey())
+                .setPrecision(2)
+                .setMax(10)
+                .setValue(ModConfig.INSTANCE.movement.verticalSpeed)
+                .setDefaultValue(() -> ModConfig.DEFAULTS.movement.verticalSpeed)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.movement.verticalSpeed = value)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.movement.verticalSpeed.@Tooltip"))
+                .build();
 
         // Add entries to the sub-category
         Stream.of(

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -165,9 +165,24 @@ public class NewConfig {
         SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.collision"))
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.@Tooltip"));
 
+        List<Component> ignoreAllTooltip = new ArrayList<>();
+        ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@Tooltip[0]"));
+        ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@Tooltip[1]"));
+        if (BuildVariant.getInstance().name().equals("modrinth")) {
+            ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@ModrinthTooltip[2]"));
+        }
+        BooleanListEntry ignoreAll = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll"),
+                        ModConfig.INSTANCE.collision.ignoreAll)
+                .setTooltip(ignoreAllTooltip.toArray(Component[]::new))
+                .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreAll)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreAll = value)
+                .build();
+
         BooleanListEntry ignoreTransparent = entryBuilder.startBooleanToggle(
                         Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent"),
                         ModConfig.INSTANCE.collision.ignoreTransparent)
+                .setRequirement(() -> !ignoreAll.getValue())
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent.@Tooltip"))
                 .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreTransparent)
                 .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreTransparent = value)
@@ -176,6 +191,7 @@ public class NewConfig {
         BooleanListEntry ignoreOpenable = entryBuilder.startBooleanToggle(
                         Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable"),
                         ModConfig.INSTANCE.collision.ignoreOpenable)
+                .setRequirement(() -> !ignoreAll.getValue())
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable.@Tooltip"))
                 .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreOpenable)
                 .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreOpenable = value)
@@ -189,6 +205,7 @@ public class NewConfig {
         BooleanListEntry ignoreCustom = entryBuilder.startBooleanToggle(
                         Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom"),
                         ModConfig.INSTANCE.collision.ignoreCustom)
+                .setRequirement(() -> !ignoreAll.getValue())
                 .setTooltip(ignoreCustomTooltip.toArray(Component[]::new))
                 .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreCustom)
                 .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreCustom = value)
@@ -214,20 +231,6 @@ public class NewConfig {
                 .setDisplayRequirement(ignoreCustom::getValue)
                 .setDefaultValue(ModConfig.DEFAULTS.collision.whitelist.patterns)
                 .setSaveConsumer(value -> ModConfig.INSTANCE.collision.whitelist.patterns = value)
-                .build();
-
-        List<Component> ignoreAllTooltip = new ArrayList<>();
-        ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@Tooltip[0]"));
-        ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@Tooltip[1]"));
-        if (BuildVariant.getInstance().name().equals("modrinth")) {
-            ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@ModrinthTooltip[2]"));
-        }
-        BooleanListEntry ignoreAll = entryBuilder.startBooleanToggle(
-                        Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll"),
-                        ModConfig.INSTANCE.collision.ignoreAll)
-                .setTooltip(ignoreAllTooltip.toArray(Component[]::new))
-                .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreAll)
-                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreAll = value)
                 .build();
 
         BooleanListEntry alwaysCheck = entryBuilder.startBooleanToggle(

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -42,10 +42,15 @@ public class NewConfig {
         return builder;
     }
 
+    // Serialise the config into the config file.
+    // This will be called last after all variables are updated.
     private static void save() {
-        // TODO
-        // Serialise the config into the config file.
-        // This will be called last after all variables are updated.
+        try {
+            ModConfig.NEW_SERIALIZER.serialize(ModConfig.INSTANCE);
+        } catch (Exception e) {
+            // TODO: do we need to handle this?
+            throw new RuntimeException(e);
+        }
 
         // Invoke "on save" listeners
         // TODO: consider having a Collection<Runnable> to store handlers

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -1,0 +1,392 @@
+package net.xolt.freecam.config;
+
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import me.shedaniel.clothconfig2.gui.entries.BooleanListEntry;
+import me.shedaniel.clothconfig2.gui.entries.EnumListEntry;
+import me.shedaniel.clothconfig2.gui.entries.StringListListEntry;
+import me.shedaniel.clothconfig2.gui.entries.SubCategoryListEntry;
+import me.shedaniel.clothconfig2.impl.builders.KeyCodeBuilder;
+import me.shedaniel.clothconfig2.impl.builders.SubCategoryBuilder;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.xolt.freecam.config.gui.DoubleSliderEntry;
+import net.xolt.freecam.variant.api.BuildVariant;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class NewConfig {
+    /**
+     * Build a {@link ConfigBuilder} with our custom config + GUI screen
+     *
+     * @return the builder
+     */
+    public static ConfigBuilder builder() {
+        ConfigBuilder builder = ConfigBuilder.create()
+                .setTitle(Component.translatable("text.autoconfig.freecam.title"))
+                // .setGlobalized(true) // Adds a sidebar menu
+                .transparentBackground()
+                .setSavingRunnable(NewConfig::save);
+
+        // Shared entry builder instance
+        ConfigEntryBuilder entryBuilder = builder.entryBuilder();
+
+        // Create & populate the "default" top-level category
+        // This mutates the builder by adding a new "category" to it
+        defaultCategory(builder, entryBuilder);
+
+        return builder;
+    }
+
+    private static void save() {
+        // TODO
+        // Serialise the config into the config file.
+        // This will be called last after all variables are updated.
+    }
+
+    // TODO: do we need separate `builder` and `getConfigScreen` methods,
+    //  or can we just have one single `buildConfigScreen` method?
+    public static Screen getConfigScreen(Screen parent) {
+        return builder().setParentScreen(parent).build();
+    }
+
+    /** Creates the top-level category.
+     * Note: category tabs are only shown if multible cateories are registered. Maybe we should consider having category tabs instead of collapsible sub-categories?
+     */
+    private static ConfigCategory defaultCategory(ConfigBuilder configBuilder, ConfigEntryBuilder entryBuilder) {
+        ConfigCategory category = configBuilder.getOrCreateCategory(Component.empty());
+
+        // Add entries to the category
+        // Currently this will be sub-categories
+        Stream.of(
+                controlsCategory(entryBuilder),
+                movementCategory(entryBuilder),
+                collisionCategory(entryBuilder),
+                visualCategory(entryBuilder),
+                utilityCategory(entryBuilder),
+                serversCategory(entryBuilder),
+                notificationCategory(entryBuilder)
+        ).forEach(category::addEntry);
+
+        return category;
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the controls sub-category
+     */
+    private static SubCategoryListEntry controlsCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.controls"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.controls.@Tooltip"));
+
+        // Add a KeyCodeEntry for each binding in ModBindings
+        ModBindings.stream()
+                .map(bind -> entryBuilder.fillKeybindingField(Component.translatable(bind.getName()), bind))
+                .map(KeyCodeBuilder::build)
+                .forEach(builder::add);
+
+        return builder.build();
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the movement sub-category
+     */
+    private static SubCategoryListEntry movementCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.movement"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.movement.@Tooltip"));
+
+        EnumListEntry<ModConfig.FlightMode> flightMode = entryBuilder.startEnumSelector(
+                        Component.translatable("text.autoconfig.freecam.option.movement.flightMode"),
+                        ModConfig.FlightMode.class,
+                        ModConfig.FlightMode.DEFAULT) // FIXME load from a real config
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.movement.flightMode.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        DoubleSliderEntry horizontalSpeed = new DoubleSliderEntry(
+                Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed"),
+                2,
+                0,
+                10,
+                1, // FIXME load from config
+                Component.translatable("text.cloth-config.reset_value"),
+                () -> 1.0,
+                val -> { } // TODO save to config
+
+        );
+        horizontalSpeed.setTooltipSupplier(() -> Optional.of(new Component[]{
+                Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed.@Tooltip")
+        }));
+
+        DoubleSliderEntry verticalSpeed = new DoubleSliderEntry(
+                Component.translatable("text.autoconfig.freecam.option.movement.verticalSpeed"),
+                2,
+                0,
+                10,
+                1, // FIXME load from config
+                Component.translatable("text.cloth-config.reset_value"),
+                () -> 1.0,
+                val -> { } // TODO save to config
+
+        );
+        verticalSpeed.setTooltipSupplier(() -> Optional.of(new Component[]{
+                Component.translatable("text.autoconfig.freecam.option.movement.verticalSpeed.@Tooltip")
+        }));
+
+        // Add entries to the sub-category
+        Stream.of(
+                flightMode,
+                horizontalSpeed,
+                verticalSpeed
+        ).forEach(builder::add);
+
+        return builder.build();
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the collision sub-category
+     */
+    private static SubCategoryListEntry collisionCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.collision"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.@Tooltip"));
+
+        BooleanListEntry ignoreTransparent = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent"), false)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry ignoreOpenable = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable"), false)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        List<Component> ignoreCustomTooltip = new ArrayList<>();
+        ignoreCustomTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom.@Tooltip[0]"));
+        if (BuildVariant.getInstance().name().equals("modrinth")) {
+            ignoreCustomTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom.@ModrinthTooltip[1]"));
+        }
+        BooleanListEntry ignoreCustom = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom"), !BuildVariant.getInstance().name().equals("modrinth"))
+                .setTooltip(ignoreCustomTooltip.toArray(Component[]::new))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        StringListListEntry idWhitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids"), new ArrayList<>())
+                .setTooltip(
+                        Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[0]"),
+                        Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[1]"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        StringListListEntry patternWhitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns"), new ArrayList<>())
+                .setTooltip(
+                        Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[0]"),
+                        Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[1]"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        List<Component> ignoreAllTooltip = new ArrayList<>();
+        ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@Tooltip[0]"));
+        ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@Tooltip[1]"));
+        if (BuildVariant.getInstance().name().equals("modrinth")) {
+            ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@ModrinthTooltip[2]"));
+        }
+        BooleanListEntry ignoreAll = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll"), !BuildVariant.getInstance().name().equals("modrinth"))
+                .setTooltip(ignoreAllTooltip.toArray(Component[]::new))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry alwaysCheck = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck"), false)
+                .setTooltip(
+                        Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck.@Tooltip[0]"),
+                        Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck.@Tooltip[1]"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        // Add entries to the sub-category
+        Stream.of(
+                ignoreTransparent,
+                ignoreOpenable,
+                ignoreCustom,
+                idWhitelist,
+                patternWhitelist,
+                ignoreAll,
+                alwaysCheck
+        ).forEach(builder::add);
+
+        return builder.build();
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the visual sub-category
+     */
+    private static SubCategoryListEntry visualCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.visual"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.@Tooltip"));
+
+        EnumListEntry<ModConfig.Perspective> perspective = entryBuilder.startEnumSelector(
+                        Component.translatable("text.autoconfig.freecam.option.visual.perspective"),
+                        ModConfig.Perspective.class,
+                        ModConfig.Perspective.INSIDE) // FIXME load from a real config
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.perspective.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry showPlayer = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showPlayer"), true)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showPlayer.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry showHand = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showHand"), false)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showHand.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry fullBright = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.fullBright"), false)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.fullBright.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry showSubmersion = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion"), false)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        // Add entries to the sub-category
+        Stream.of(
+                perspective,
+                showPlayer,
+                showHand,
+                fullBright,
+                showSubmersion
+        ).forEach(builder::add);
+
+        return builder.build();
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the utility sub-category
+     */
+    private static SubCategoryListEntry utilityCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.utility"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.@Tooltip"));
+
+        BooleanListEntry disableOnDamage = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage"), true)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry freezePlayer = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.freezePlayer"), false)
+                .setTooltip(
+                        Component.translatable("text.autoconfig.freecam.option.utility.freezePlayer.@Tooltip[0]"),
+                        Component.translatable(
+                                BuildVariant.getInstance().name().equals("modrinth")
+                                ? "text.autoconfig.freecam.option.utility.freezePlayer.@ModrinthTooltip[1]"
+                                : "text.autoconfig.freecam.option.utility.freezePlayer.@Tooltip[1]"
+                        )
+                )
+                // .setSaveConsumer() // TODO
+                .build();
+
+        List<Component> allowInteractTooltip = new ArrayList<>();
+        allowInteractTooltip.add(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract.@Tooltip[0]"));
+        allowInteractTooltip.add(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract.@Tooltip[1]"));
+        if (BuildVariant.getInstance().name().equals("modrinth")) {
+            allowInteractTooltip.add(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract.@ModrinthTooltip[2]"));
+        }
+        BooleanListEntry allowInteract = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract"), false)
+                .setTooltip(allowInteractTooltip.toArray(Component[]::new))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        EnumListEntry<ModConfig.InteractionMode> interactionMode = entryBuilder.startEnumSelector(
+                        Component.translatable("text.autoconfig.freecam.option.utility.interactionMode"),
+                        ModConfig.InteractionMode.class,
+                        ModConfig.InteractionMode.CAMERA) // FIXME load from a real config
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.interactionMode.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        // Add entries to the sub-category
+        Stream.of(
+                disableOnDamage,
+                freezePlayer,
+                allowInteract,
+                interactionMode
+        ).forEach(builder::add);
+
+        return builder.build();
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the servers sub-category
+     */
+    private static SubCategoryListEntry serversCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.servers"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.servers.@Tooltip"));
+
+        EnumListEntry<ModConfig.ServerRestriction> mode = entryBuilder.startEnumSelector(
+                        Component.translatable("text.autoconfig.freecam.option.servers.mode"),
+                        ModConfig.ServerRestriction.class,
+                        ModConfig.ServerRestriction.NONE) // FIXME load from a real config
+                .setTooltip(
+                        Component.translatable("text.autoconfig.freecam.option.servers.mode.@Tooltip[0]"),
+                        Component.translatable("text.autoconfig.freecam.option.servers.mode.@Tooltip[1]"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        StringListListEntry whitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.whitelist"), new ArrayList<>())
+                // .setTooltip()
+                // .setSaveConsumer() // TODO
+                .build();
+
+        StringListListEntry blacklist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.blacklist"), new ArrayList<>())
+                // .setTooltip()
+                // .setSaveConsumer() // TODO
+                .build();
+
+        // Add entries to the sub-category
+        Stream.of(
+                mode,
+                whitelist,
+                blacklist
+        ).forEach(builder::add);
+
+        return builder.build();
+    }
+
+    /**
+     * @param entryBuilder {@link ConfigEntryBuilder cloth-config entry builder}
+     * @return the notification sub-category
+     */
+    private static SubCategoryListEntry notificationCategory(ConfigEntryBuilder entryBuilder) {
+        SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.notification"))
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.@Tooltip"));
+
+        BooleanListEntry notifyFreecam = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam"), true)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        BooleanListEntry notifyTripod = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod"), true)
+                .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod.@Tooltip"))
+                // .setSaveConsumer() // TODO
+                .build();
+
+        // Add entries to the sub-category
+        Stream.of(
+                notifyFreecam,
+                notifyTripod
+        ).forEach(builder::add);
+
+        return builder.build();
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -185,6 +185,7 @@ public class NewConfig {
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[1]"))
+                .setDisplayRequirement(ignoreCustom::getValue)
                 .setDefaultValue(Collections.emptyList())
                 // .setSaveConsumer() // TODO
                 .build();
@@ -193,6 +194,7 @@ public class NewConfig {
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[1]"))
+                .setDisplayRequirement(ignoreCustom::getValue)
                 .setDefaultValue(Collections.emptyList())
                 // .setSaveConsumer() // TODO
                 .build();
@@ -364,12 +366,14 @@ public class NewConfig {
 
         StringListListEntry whitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.whitelist"), new ArrayList<>())
                 // .setTooltip()
+                .setDisplayRequirement(() -> mode.getValue() == ModConfig.ServerRestriction.WHITELIST)
                 .setDefaultValue(Collections.emptyList()) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();
 
         StringListListEntry blacklist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.blacklist"), new ArrayList<>())
                 // .setTooltip()
+                .setDisplayRequirement(() -> mode.getValue() == ModConfig.ServerRestriction.BLACKLIST)
                 .setDefaultValue(Collections.emptyList()) // TODO get from config api
                 // .setSaveConsumer() // TODO
                 .build();

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -15,7 +15,6 @@ import net.xolt.freecam.config.gui.DoubleSliderEntry;
 import net.xolt.freecam.variant.api.BuildVariant;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -104,10 +103,10 @@ public class NewConfig {
         EnumListEntry<ModConfig.FlightMode> flightMode = entryBuilder.startEnumSelector(
                         Component.translatable("text.autoconfig.freecam.option.movement.flightMode"),
                         ModConfig.FlightMode.class,
-                        ModConfig.FlightMode.DEFAULT) // FIXME load from a real config
+                        ModConfig.INSTANCE.movement.flightMode)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.movement.flightMode.@Tooltip"))
-                .setDefaultValue(ModConfig.FlightMode.DEFAULT) // FIXME load from a config API
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.movement.flightMode)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.movement.flightMode = value)
                 .build();
 
         DoubleSliderEntry horizontalSpeed = new DoubleSliderEntry(
@@ -115,11 +114,10 @@ public class NewConfig {
                 2,
                 0,
                 10,
-                1, // FIXME load from config
+                ModConfig.INSTANCE.movement.horizontalSpeed,
                 Component.translatable("text.cloth-config.reset_value"),
-                () -> 1.0, // TODO get from config system
-                val -> { } // TODO save to config
-
+                () -> ModConfig.DEFAULTS.movement.horizontalSpeed,
+                value -> ModConfig.INSTANCE.movement.horizontalSpeed = value
         );
         horizontalSpeed.setTooltipSupplier(() -> Optional.of(new Component[]{
                 Component.translatable("text.autoconfig.freecam.option.movement.horizontalSpeed.@Tooltip")
@@ -130,10 +128,10 @@ public class NewConfig {
                 2,
                 0,
                 10,
-                1, // FIXME load from config
+                ModConfig.INSTANCE.movement.verticalSpeed,
                 Component.translatable("text.cloth-config.reset_value"),
-                () -> 1.0, // TODO get from config system
-                val -> { } // TODO save to config
+                () -> ModConfig.DEFAULTS.movement.verticalSpeed,
+                value -> ModConfig.INSTANCE.movement.verticalSpeed = value
 
         );
         verticalSpeed.setTooltipSupplier(() -> Optional.of(new Component[]{
@@ -158,16 +156,20 @@ public class NewConfig {
         SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.collision"))
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.@Tooltip"));
 
-        BooleanListEntry ignoreTransparent = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent"), false)
+        BooleanListEntry ignoreTransparent = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent"),
+                        ModConfig.INSTANCE.collision.ignoreTransparent)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreTransparent.@Tooltip"))
-                .setDefaultValue(false) // TODO get from config system
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreTransparent)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreTransparent = value)
                 .build();
 
-        BooleanListEntry ignoreOpenable = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable"), false)
+        BooleanListEntry ignoreOpenable = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable"),
+                        ModConfig.INSTANCE.collision.ignoreOpenable)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.collision.ignoreOpenable.@Tooltip"))
-                .setDefaultValue(false) // TODO get from config
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreOpenable)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreOpenable = value)
                 .build();
 
         List<Component> ignoreCustomTooltip = new ArrayList<>();
@@ -175,28 +177,34 @@ public class NewConfig {
         if (BuildVariant.getInstance().name().equals("modrinth")) {
             ignoreCustomTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom.@ModrinthTooltip[1]"));
         }
-        BooleanListEntry ignoreCustom = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom"), !BuildVariant.getInstance().name().equals("modrinth"))
+        BooleanListEntry ignoreCustom = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.collision.ignoreCustom"),
+                        ModConfig.INSTANCE.collision.ignoreCustom)
                 .setTooltip(ignoreCustomTooltip.toArray(Component[]::new))
-                .setDefaultValue(!BuildVariant.getInstance().name().equals("modrinth")) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreCustom)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreCustom = value)
                 .build();
 
-        StringListListEntry idWhitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids"), new ArrayList<>())
+        StringListListEntry idWhitelist = entryBuilder.startStrList(
+                        Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids"),
+                        ModConfig.INSTANCE.collision.whitelist.ids)
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.ids.@Tooltip[1]"))
                 .setDisplayRequirement(ignoreCustom::getValue)
-                .setDefaultValue(Collections.emptyList())
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.whitelist.ids)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.whitelist.ids = value)
                 .build();
 
-        StringListListEntry patternWhitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns"), new ArrayList<>())
+        StringListListEntry patternWhitelist = entryBuilder.startStrList(
+                        Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns"),
+                        ModConfig.INSTANCE.collision.whitelist.patterns)
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.whitelist.patterns.@Tooltip[1]"))
                 .setDisplayRequirement(ignoreCustom::getValue)
-                .setDefaultValue(Collections.emptyList())
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.whitelist.patterns)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.whitelist.patterns = value)
                 .build();
 
         List<Component> ignoreAllTooltip = new ArrayList<>();
@@ -205,18 +213,22 @@ public class NewConfig {
         if (BuildVariant.getInstance().name().equals("modrinth")) {
             ignoreAllTooltip.add(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll.@ModrinthTooltip[2]"));
         }
-        BooleanListEntry ignoreAll = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll"), !BuildVariant.getInstance().name().equals("modrinth"))
+        BooleanListEntry ignoreAll = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.collision.ignoreAll"),
+                        ModConfig.INSTANCE.collision.ignoreAll)
                 .setTooltip(ignoreAllTooltip.toArray(Component[]::new))
-                .setDefaultValue(!BuildVariant.getInstance().name().equals("modrinth")) // TODO get from config system
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.ignoreAll)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.ignoreAll = value)
                 .build();
 
-        BooleanListEntry alwaysCheck = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck"), false)
+        BooleanListEntry alwaysCheck = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck"),
+                        ModConfig.INSTANCE.collision.alwaysCheck)
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.collision.alwaysCheck.@Tooltip[1]"))
-                .setDefaultValue(false) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.collision.alwaysCheck)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.collision.alwaysCheck = value)
                 .build();
 
         // Add entries to the sub-category
@@ -244,34 +256,42 @@ public class NewConfig {
         EnumListEntry<ModConfig.Perspective> perspective = entryBuilder.startEnumSelector(
                         Component.translatable("text.autoconfig.freecam.option.visual.perspective"),
                         ModConfig.Perspective.class,
-                        ModConfig.Perspective.INSIDE) // FIXME load from a real config
+                        ModConfig.INSTANCE.visual.perspective)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.perspective.@Tooltip"))
-                .setDefaultValue(ModConfig.Perspective.INSIDE) // TODO get from config system
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.visual.perspective)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.visual.perspective = value)
                 .build();
 
-        BooleanListEntry showPlayer = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showPlayer"), true)
+        BooleanListEntry showPlayer = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.visual.showPlayer"),
+                        ModConfig.INSTANCE.visual.showPlayer)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showPlayer.@Tooltip"))
-                .setDefaultValue(true) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.visual.showPlayer)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.visual.showPlayer = value)
                 .build();
 
-        BooleanListEntry showHand = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showHand"), false)
+        BooleanListEntry showHand = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.visual.showHand"),
+                        ModConfig.INSTANCE.visual.showHand)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showHand.@Tooltip"))
-                .setDefaultValue(false) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.visual.showHand)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.visual.showHand = value)
                 .build();
 
-        BooleanListEntry fullBright = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.fullBright"), false)
+        BooleanListEntry fullBright = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.visual.fullBright"),
+                        ModConfig.INSTANCE.visual.fullBright)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.fullBright.@Tooltip"))
-                .setDefaultValue(false) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.visual.fullBright)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.visual.fullBright = value)
                 .build();
 
-        BooleanListEntry showSubmersion = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion"), false)
+        BooleanListEntry showSubmersion = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion"),
+                        ModConfig.INSTANCE.visual.showSubmersion)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.visual.showSubmersion.@Tooltip"))
-                .setDefaultValue(false) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.visual.showSubmersion)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.visual.showSubmersion = value)
                 .build();
 
         // Add entries to the sub-category
@@ -294,13 +314,17 @@ public class NewConfig {
         SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.utility"))
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.@Tooltip"));
 
-        BooleanListEntry disableOnDamage = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage"), true)
+        BooleanListEntry disableOnDamage = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage"),
+                        ModConfig.INSTANCE.utility.disableOnDamage)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.disableOnDamage.@Tooltip"))
-                .setDefaultValue(true) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.utility.disableOnDamage)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.utility.disableOnDamage = value)
                 .build();
 
-        BooleanListEntry freezePlayer = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.freezePlayer"), false)
+        BooleanListEntry freezePlayer = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.utility.freezePlayer"),
+                        ModConfig.INSTANCE.utility.freezePlayer)
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.utility.freezePlayer.@Tooltip[0]"),
                         Component.translatable(
@@ -309,8 +333,8 @@ public class NewConfig {
                                 : "text.autoconfig.freecam.option.utility.freezePlayer.@Tooltip[1]"
                         )
                 )
-                .setDefaultValue(false) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.utility.freezePlayer)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.utility.freezePlayer = value)
                 .build();
 
         List<Component> allowInteractTooltip = new ArrayList<>();
@@ -319,19 +343,21 @@ public class NewConfig {
         if (BuildVariant.getInstance().name().equals("modrinth")) {
             allowInteractTooltip.add(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract.@ModrinthTooltip[2]"));
         }
-        BooleanListEntry allowInteract = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.utility.allowInteract"), false)
+        BooleanListEntry allowInteract = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.utility.allowInteract"),
+                        ModConfig.INSTANCE.utility.allowInteract)
                 .setTooltip(allowInteractTooltip.toArray(Component[]::new))
-                .setDefaultValue(false) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.utility.allowInteract)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.utility.allowInteract = value)
                 .build();
 
         EnumListEntry<ModConfig.InteractionMode> interactionMode = entryBuilder.startEnumSelector(
                         Component.translatable("text.autoconfig.freecam.option.utility.interactionMode"),
                         ModConfig.InteractionMode.class,
-                        ModConfig.InteractionMode.CAMERA) // FIXME load from a real config
+                        ModConfig.INSTANCE.utility.interactionMode)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.utility.interactionMode.@Tooltip"))
-                .setDefaultValue(ModConfig.InteractionMode.CAMERA) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.utility.interactionMode)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.utility.interactionMode = value)
                 .build();
 
         // Add entries to the sub-category
@@ -356,26 +382,30 @@ public class NewConfig {
         EnumListEntry<ModConfig.ServerRestriction> mode = entryBuilder.startEnumSelector(
                         Component.translatable("text.autoconfig.freecam.option.servers.mode"),
                         ModConfig.ServerRestriction.class,
-                        ModConfig.ServerRestriction.NONE) // FIXME load from a real config
+                        ModConfig.INSTANCE.servers.mode)
                 .setTooltip(
                         Component.translatable("text.autoconfig.freecam.option.servers.mode.@Tooltip[0]"),
                         Component.translatable("text.autoconfig.freecam.option.servers.mode.@Tooltip[1]"))
-                .setDefaultValue(ModConfig.ServerRestriction.NONE) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.servers.mode)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.servers.mode = value)
                 .build();
 
-        StringListListEntry whitelist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.whitelist"), new ArrayList<>())
+        StringListListEntry whitelist = entryBuilder.startStrList(
+                        Component.translatable("text.autoconfig.freecam.option.servers.whitelist"),
+                        ModConfig.INSTANCE.servers.whitelist)
                 // .setTooltip()
                 .setDisplayRequirement(() -> mode.getValue() == ModConfig.ServerRestriction.WHITELIST)
-                .setDefaultValue(Collections.emptyList()) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.servers.whitelist)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.servers.whitelist = value)
                 .build();
 
-        StringListListEntry blacklist = entryBuilder.startStrList(Component.translatable("text.autoconfig.freecam.option.servers.blacklist"), new ArrayList<>())
+        StringListListEntry blacklist = entryBuilder.startStrList(
+                        Component.translatable("text.autoconfig.freecam.option.servers.blacklist"),
+                        ModConfig.INSTANCE.servers.blacklist)
                 // .setTooltip()
                 .setDisplayRequirement(() -> mode.getValue() == ModConfig.ServerRestriction.BLACKLIST)
-                .setDefaultValue(Collections.emptyList()) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.servers.whitelist)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.servers.whitelist = value)
                 .build();
 
         // Add entries to the sub-category
@@ -396,16 +426,20 @@ public class NewConfig {
         SubCategoryBuilder builder = entryBuilder.startSubCategory(Component.translatable("text.autoconfig.freecam.option.notification"))
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.@Tooltip"));
 
-        BooleanListEntry notifyFreecam = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam"), true)
+        BooleanListEntry notifyFreecam = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam"),
+                        ModConfig.INSTANCE.notification.notifyFreecam)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.notifyFreecam.@Tooltip"))
-                .setDefaultValue(true) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.notification.notifyFreecam)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.notification.notifyFreecam = value)
                 .build();
 
-        BooleanListEntry notifyTripod = entryBuilder.startBooleanToggle(Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod"), true)
+        BooleanListEntry notifyTripod = entryBuilder.startBooleanToggle(
+                        Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod"),
+                        ModConfig.INSTANCE.notification.notifyTripod)
                 .setTooltip(Component.translatable("text.autoconfig.freecam.option.notification.notifyTripod.@Tooltip"))
-                .setDefaultValue(true) // TODO get from config api
-                // .setSaveConsumer() // TODO
+                .setDefaultValue(ModConfig.DEFAULTS.notification.notifyTripod)
+                .setSaveConsumer(value -> ModConfig.INSTANCE.notification.notifyTripod = value)
                 .build();
 
         // Add entries to the sub-category

--- a/common/src/main/java/net/xolt/freecam/config/NewConfig.java
+++ b/common/src/main/java/net/xolt/freecam/config/NewConfig.java
@@ -46,6 +46,10 @@ public class NewConfig {
         // TODO
         // Serialise the config into the config file.
         // This will be called last after all variables are updated.
+
+        // Invoke "on save" listeners
+        // TODO: consider having a Collection<Runnable> to store handlers
+        CollisionBehavior.onConfigChange(ModConfig.INSTANCE);
     }
 
     // TODO: do we need separate `builder` and `getConfigScreen` methods,

--- a/common/src/main/java/net/xolt/freecam/config/gui/BoundedContinuousImpl.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/BoundedContinuousImpl.java
@@ -5,7 +5,6 @@ import me.shedaniel.autoconfig.util.Utils;
 import net.minecraft.network.chat.Component;
 
 import java.util.Collections;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static net.xolt.freecam.config.gui.AutoConfigExtensions.RESET_TEXT;
@@ -18,11 +17,16 @@ class BoundedContinuousImpl {
 
         registry.registerAnnotationProvider(
                 (i18n, field, config, defaults, guiProvider) -> {
-                    Consumer<Double> save = newValue -> Utils.setUnsafely(field, config, newValue);
-                    Supplier<Double> defaultValue = () -> Utils.getUnsafely(field, defaults);
-                    double value = Utils.getUnsafely(field, config, defaultValue.get());
                     BoundedContinuous bounds = field.getAnnotation(BoundedContinuous.class);
-                    return Collections.singletonList(new DoubleSliderEntry(Component.translatable(i18n), bounds.precision(), bounds.min(), bounds.max(), value, RESET_TEXT, defaultValue, save));
+                    DoubleSliderEntry entry = DoubleSliderEntry.builder(Component.translatable(i18n), RESET_TEXT)
+                            .setPrecision(bounds.precision())
+                            .setMin(bounds.min())
+                            .setMax(bounds.max())
+                            .setValue(Utils.getUnsafely(field, config, 0))
+                            .setDefaultValue(() -> Utils.getUnsafely(field, defaults))
+                            .setSaveConsumer(newValue -> Utils.setUnsafely(field, config, newValue))
+                            .build();
+                    return Collections.singletonList(entry);
                 },
                 field -> field.getType() == Double.TYPE || field.getType() == Double.class,
                 BoundedContinuous.class

--- a/common/src/main/java/net/xolt/freecam/config/gui/DoubleSliderBuilder.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/DoubleSliderBuilder.java
@@ -1,0 +1,47 @@
+package net.xolt.freecam.config.gui;
+
+import me.shedaniel.clothconfig2.impl.builders.AbstractFieldBuilder;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+
+public class DoubleSliderBuilder extends AbstractFieldBuilder<Double, DoubleSliderEntry, DoubleSliderBuilder> {
+    private int precision = 2;
+    private double min = 0;
+    private double max;
+    private double value;
+
+    DoubleSliderBuilder(Component fieldName, Component resetButtonKey) {
+        super(resetButtonKey, fieldName);
+    }
+
+    public DoubleSliderBuilder setPrecision(int precision) {
+        this.precision = precision;
+        return this;
+    }
+
+    public DoubleSliderBuilder setMin(double min) {
+        this.min = min;
+        return this;
+    }
+
+    public DoubleSliderBuilder setMax(double max) {
+        this.max = max;
+        return this;
+    }
+
+    public DoubleSliderBuilder setValue(double value) {
+        this.value = value;
+        return this;
+    }
+
+    public @NotNull DoubleSliderEntry build() {
+        DoubleSliderEntry entry = new DoubleSliderEntry(this.getFieldNameKey(), this.precision, this.min, this.max, this.value, this.getResetButtonKey(), this.getDefaultValue(), this.getSaveConsumer());
+
+        entry.setTooltipSupplier(() -> this.getTooltipSupplier().apply(entry.getValue()));
+        if (this.errorSupplier != null) {
+            entry.setErrorSupplier(() -> this.errorSupplier.apply(entry.getValue()));
+        }
+
+        return this.finishBuilding(entry);
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/gui/DoubleSliderEntry.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/DoubleSliderEntry.java
@@ -28,7 +28,7 @@ import static net.xolt.freecam.Freecam.MC;
 /**
  * {@link IntegerSliderEntry} ported from {@code int} to {@code double}.
  */
-class DoubleSliderEntry extends TooltipListEntry<Double> {
+public class DoubleSliderEntry extends TooltipListEntry<Double> {
     private final Slider sliderWidget;
     private final Button resetButton;
     private final AtomicDouble value;
@@ -39,7 +39,7 @@ class DoubleSliderEntry extends TooltipListEntry<Double> {
     private final Supplier<Double> defaultValue;
     private final List<AbstractWidget> widgets;
 
-    DoubleSliderEntry(Component fieldName, int precision, double minimum, double maximum, double value, Component resetText, Supplier<Double> defaultValue, @Nullable Consumer<Double> save) {
+    public DoubleSliderEntry(Component fieldName, int precision, double minimum, double maximum, double value, Component resetText, Supplier<Double> defaultValue, @Nullable Consumer<Double> save) {
         //noinspection deprecation,UnstableApiUsage
         super(fieldName, null);
         this.value = new AtomicDouble(value);

--- a/common/src/main/java/net/xolt/freecam/config/gui/DoubleSliderEntry.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/DoubleSliderEntry.java
@@ -2,6 +2,7 @@ package net.xolt.freecam.config.gui;
 
 import com.google.common.util.concurrent.AtomicDouble;
 import com.mojang.blaze3d.platform.Window;
+import me.shedaniel.clothconfig2.gui.entries.IntegerSliderEntry;
 import me.shedaniel.clothconfig2.gui.entries.TooltipListEntry;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractSliderButton;
@@ -39,7 +40,11 @@ public class DoubleSliderEntry extends TooltipListEntry<Double> {
     private final Supplier<Double> defaultValue;
     private final List<AbstractWidget> widgets;
 
-    public DoubleSliderEntry(Component fieldName, int precision, double minimum, double maximum, double value, Component resetText, Supplier<Double> defaultValue, @Nullable Consumer<Double> save) {
+    public static DoubleSliderBuilder builder(Component i18n, Component resetButtonKey) {
+        return new DoubleSliderBuilder(i18n, resetButtonKey);
+    }
+
+    DoubleSliderEntry(Component fieldName, int precision, double minimum, double maximum, double value, Component resetText, Supplier<Double> defaultValue, @Nullable Consumer<Double> save) {
         //noinspection deprecation,UnstableApiUsage
         super(fieldName, null);
         this.value = new AtomicDouble(value);

--- a/fabric/src/main/java/net/xolt/freecam/fabric/ModMenuIntegration.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/ModMenuIntegration.java
@@ -5,13 +5,18 @@ import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.screens.Screen;
 import net.xolt.freecam.config.ModConfig;
+import net.xolt.freecam.config.NewConfig;
 
 @Environment(EnvType.CLIENT)
 public class ModMenuIntegration implements ModMenuApi {
 
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> AutoConfig.getConfigScreen(ModConfig.class, parent).get();
+        return parent ->
+                Screen.hasShiftDown()
+                ? NewConfig.getConfigScreen(parent)
+                : AutoConfig.getConfigScreen(ModConfig.class, parent).get();
     }
 }

--- a/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
@@ -2,6 +2,7 @@ package net.xolt.freecam.forge;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -15,6 +16,7 @@ import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
+import net.xolt.freecam.config.NewConfig;
 
 @Mod(Freecam.MOD_ID)
 @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
@@ -25,7 +27,9 @@ public class FreecamForge {
         ModConfig.init();
         // Register our config screen with Forge
         container.registerExtensionPoint(IConfigScreenFactory.class, (client, parent) ->
-                AutoConfig.getConfigScreen(ModConfig.class, parent).get());
+                Screen.hasShiftDown()
+                        ? NewConfig.getConfigScreen(parent)
+                        : AutoConfig.getConfigScreen(ModConfig.class, parent).get());
     }
 
     @SubscribeEvent


### PR DESCRIPTION
Port from AutoConfig to the less abstracted cloth-config2.

Strictly speaking, AutoConfig is part of the cloth-config project, so we aren't dropping any dependencies yet. But we are taking ownership of how our config is persisted.

The current JSON persistence implementation simply matches what AutoConfig does; the point of this PR is not to change any functionality, but simply to shift responsibility.

I've marked the PR a draft for now until it can be further tested and polished, but it should be ready for testing and review.

We ought to be cautious here, we don't want to end up breaking user configs just for an internal refactor!
