### PR TITLE
Bump to 1.21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,25 +26,26 @@ release_type=release
 # https://maven.parchmentmc.org/org/parchmentmc/data
 # Forge dependencies use maven's version range spec:
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
-minecraft_version=1.21.6
+minecraft_version=1.21.7
 parchment_version=1.21.6-2025.06.29
 supported_mc_versions=
 
 fabric_loader_version=0.16.14
-fabric_api_version=0.127.1+1.21.6
+fabric_api_version=0.128.2+1.21.7
 fabric_loader_req=>=0.14.0
-fabric_mc_req=>1.21.6-
+fabric_mc_req=>1.21.7-
 fabric_supported_mc_versions=
 
-neoforge_version=21.6.11-beta
+neoforge_version=21.7.10-beta
 neoforge_pr=
-neoforge_mc_req=[1.21.6,)
+neoforge_mc_req=[1.21.7,)
 neoforge_loader_req=[1,)
-neoforge_req=[21.5.0-beta,)
+neoforge_req=[21.7.3-beta,)
 neoforge_supported_mc_versions=
 
 # Other dependencies
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu
 # https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config?repo=architectury
+# FIXME
 modmenu_version=15.0.0-beta.3
 cloth_version=19.0.147

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ release_type=release
 # Forge dependencies use maven's version range spec:
 # https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
 minecraft_version=1.21.6
-parchment_version=1.21.5-2025.06.15
+parchment_version=1.21.6-2025.06.29
 supported_mc_versions=
 
 fabric_loader_version=0.16.14


### PR DESCRIPTION
- **build: bump parchment to 1.21.6-2025.06.29**
This commit can be kept on the 1.21.6 code.

- **build: update to 1.21.7**
Bump to 1.21.7. Changes seem minimal, no mappings conflicts, etc.

modmenu and cloth-config have not released updates yet, however both still work.

cloth-config shows warnings in neoforge because it is still using `@OnlyIn`, which is deprecated in favour of checking [`Level#isClientSide()`](https://docs.neoforged.net/docs/concepts/sides/#levelisclientside) and [`dist = Dist.CLIENT`](https://docs.neoforged.net/docs/concepts/sides/#fmlenvironmentdist). See https://github.com/neoforged/NeoForge/pull/2397. Incidentally, this is probably what's causing https://github.com/MinecraftFreecam/Freecam/issues/290, I'll investigate a fix separately to this PR.
