### PR TITLE
fix(neoforge): Mark the entrypoint as client-side

### DIFF
--- a/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
@@ -8,7 +8,6 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
@@ -16,7 +15,7 @@ import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.ModBindings;
 import net.xolt.freecam.config.ModConfig;
 
-@Mod(Freecam.MOD_ID)
+@Mod(value = Freecam.MOD_ID, dist = Dist.CLIENT)
 @EventBusSubscriber(value = Dist.CLIENT)
 @SuppressWarnings("unused")
 public class FreecamForge {


### PR DESCRIPTION
While the EventBusSubscriber is already marked as client-side, the Mod entrypoint should also be marked as such.

See https://docs.neoforged.net/docs/concepts/sides
and https://docs.neoforged.net/docs/gettingstarted/modfiles/#javafml-and-mod

This should fix https://github.com/MinecraftFreecam/Freecam/issues/290 (not tested).
