### PR TITLE
ci(build_matrix): store static matrix jobs as TOML

### DIFF
--- a/ci/matrix_jobs.toml
+++ b/ci/matrix_jobs.toml
@@ -1,0 +1,3 @@
+[[build]]
+name = "Build logic tests"
+gradle_args = ["--project-dir", "build-logic", ":check"]

--- a/ci/src/freecam_ci/build_matrix.py
+++ b/ci/src/freecam_ci/build_matrix.py
@@ -5,57 +5,15 @@ Used by .github/workflows/build.yml (prepare) to generate the job matrix.
 import argparse
 import json
 import tomllib as toml
-from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 import json5
 
+from .matrix_model import MatrixJob
 from .project_files import MATRIX_JOBS_FILE, STONECUTTER_FILE
 from .read_version import read_version
 from .stonecutter_model import ProjectEntry
-
-
-@dataclass
-class MatrixJob:
-    """A job in a GHA 'include' matrix."""
-
-    name: str
-    gradle_args: List[str]
-    upload_name: str | None = None
-    upload_path: str | None = None
-    upload_days: int | None = None
-
-    def to_dict(self) -> dict:
-        """Convert to dict, omitting None values."""
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
-    @classmethod
-    def from_dict(cls, value: dict[str, Any]):
-        try:
-            job = cls(
-                name=value["name"],
-                gradle_args=value["gradle_args"],
-                upload_name=value.get("upload_name"),
-                upload_path=value.get("upload_path"),
-                upload_days=value.get("upload_days"),
-            )
-        except KeyError as e:
-            raise ValueError(f"MatrixJob missing required key {e.args[0]}") from None
-
-        if not isinstance(job.name, str):
-            raise ValueError("name must be a string")
-
-        if not isinstance(job.gradle_args, list):
-            raise ValueError("gradle_args must be a list")
-
-        if (job.upload_name is None) ^ (job.upload_path is None):
-            raise ValueError("upload_name and upload_path must be defined together")
-
-        if job.upload_days is not None and job.upload_name is None:
-            raise ValueError("upload_days requires upload_name and upload_path")
-
-        return job
 
 
 def build_version_matrix(

--- a/ci/src/freecam_ci/build_matrix.py
+++ b/ci/src/freecam_ci/build_matrix.py
@@ -60,11 +60,11 @@ class MatrixJob:
 
 def build_version_matrix(
     version: str,
-    data: dict[str, Any],
+    versions: dict[str, Any],
 ) -> list[MatrixJob]:
     matrix: list[MatrixJob] = []
 
-    for version_name, projects in data["versions"].items():
+    for version_name, projects in versions.items():
         normalized: list[ProjectEntry] = [ProjectEntry.parse(item) for item in projects]
 
         gradle_args: list[str] = [
@@ -83,6 +83,13 @@ def build_version_matrix(
         )
 
     return matrix
+
+
+def load_versions(
+    key: str = "versions", versions_file: Path = STONECUTTER_FILE
+) -> dict[str, Any]:
+    with versions_file.open("rb") as file:
+        return json5.load(file)[key]
 
 
 def load_matrix_jobs(
@@ -132,7 +139,7 @@ def main() -> None:
 
     version_jobs = build_version_matrix(
         version=args.version,
-        data=json5.loads(args.versions_file.read_text()),
+        versions=load_versions(versions_file=args.versions_file),
     )
 
     static_jobs: list[MatrixJob] = []

--- a/ci/src/freecam_ci/build_matrix.py
+++ b/ci/src/freecam_ci/build_matrix.py
@@ -4,13 +4,14 @@ Used by .github/workflows/build.yml (prepare) to generate the job matrix.
 
 import argparse
 import json
+import tomllib as toml
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any, List
 
 import json5
 
-from .project_files import STONECUTTER_FILE
+from .project_files import MATRIX_JOBS_FILE, STONECUTTER_FILE
 from .read_version import read_version
 from .stonecutter_model import ProjectEntry
 
@@ -29,8 +30,35 @@ class MatrixJob:
         """Convert to dict, omitting None values."""
         return {k: v for k, v in asdict(self).items() if v is not None}
 
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]):
+        try:
+            job = cls(
+                name=value["name"],
+                gradle_args=value["gradle_args"],
+                upload_name=value.get("upload_name"),
+                upload_path=value.get("upload_path"),
+                upload_days=value.get("upload_days"),
+            )
+        except KeyError as e:
+            raise ValueError(f"MatrixJob missing required key {e.args[0]}") from None
 
-def build_matrix(
+        if not isinstance(job.name, str):
+            raise ValueError("name must be a string")
+
+        if not isinstance(job.gradle_args, list):
+            raise ValueError("gradle_args must be a list")
+
+        if (job.upload_name is None) ^ (job.upload_path is None):
+            raise ValueError("upload_name and upload_path must be defined together")
+
+        if job.upload_days is not None and job.upload_name is None:
+            raise ValueError("upload_days requires upload_name and upload_path")
+
+        return job
+
+
+def build_version_matrix(
     version: str,
     data: dict[str, Any],
 ) -> list[MatrixJob]:
@@ -54,15 +82,23 @@ def build_matrix(
             )
         )
 
-    # Extra jobs
-    matrix.append(
-        MatrixJob(
-            name="Build logic tests",
-            gradle_args=["--project-dir", "build-logic", ":check"],
-        )
-    )
-
     return matrix
+
+
+def load_matrix_jobs(
+    key: str = "build",
+    matrix_jobs_file: Path = MATRIX_JOBS_FILE,
+) -> list[MatrixJob]:
+    with matrix_jobs_file.open("rb") as file:
+        data = toml.load(file)
+    return [MatrixJob.from_dict(job) for job in data.get(key, [])]
+
+
+def optional_path(value) -> Path | None:
+    """argparse type representing a Path or 'none'"""
+    if isinstance(value, str) and value.lower() in ["none", "null"]:
+        return None
+    return Path(value)
 
 
 def parse_args() -> argparse.Namespace:
@@ -72,6 +108,12 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=STONECUTTER_FILE,
         help="path to stonecutter config file",
+    )
+    parser.add_argument(
+        "--jobs-file",
+        type=optional_path,
+        default=MATRIX_JOBS_FILE,
+        help="path to static matrix jobs file (pass 'none' to disable)",
     )
     parser.add_argument(
         "--version", type=str, help="project version (default read from metadata.toml)"
@@ -88,13 +130,20 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    jobs = build_matrix(
+    version_jobs = build_version_matrix(
         version=args.version,
         data=json5.loads(args.versions_file.read_text()),
     )
 
+    static_jobs: list[MatrixJob] = []
+    if args.jobs_file:
+        static_jobs = load_matrix_jobs(matrix_jobs_file=args.jobs_file)
+
     # Convert all jobs to dicts for JSON output
-    matrix = [job.to_dict() for job in jobs]
+    matrix = [
+        job.to_dict()
+        for job in sorted(version_jobs + static_jobs, key=lambda job: job.name)
+    ]
 
     # Print compact to output
     if args.output:

--- a/ci/src/freecam_ci/matrix_model.py
+++ b/ci/src/freecam_ci/matrix_model.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, asdict
+from typing import List, Any
+
+
+@dataclass
+class MatrixJob:
+    """A job in a GHA 'include' matrix."""
+
+    name: str
+    gradle_args: List[str]
+    upload_name: str | None = None
+    upload_path: str | None = None
+    upload_days: int | None = None
+
+    def to_dict(self) -> dict:
+        """Convert to dict, omitting None values."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]):
+        try:
+            job = cls(
+                name=value["name"],
+                gradle_args=value["gradle_args"],
+                upload_name=value.get("upload_name"),
+                upload_path=value.get("upload_path"),
+                upload_days=value.get("upload_days"),
+            )
+        except KeyError as e:
+            raise ValueError(f"MatrixJob missing required key {e.args[0]}") from None
+
+        if not isinstance(job.name, str):
+            raise ValueError("name must be a string")
+
+        if not isinstance(job.gradle_args, list):
+            raise ValueError("gradle_args must be a list")
+
+        if (job.upload_name is None) ^ (job.upload_path is None):
+            raise ValueError("upload_name and upload_path must be defined together")
+
+        if job.upload_days is not None and job.upload_name is None:
+            raise ValueError("upload_days requires upload_name and upload_path")
+
+        return job

--- a/ci/src/freecam_ci/project_files.py
+++ b/ci/src/freecam_ci/project_files.py
@@ -5,3 +5,4 @@ ROOT = CI.parent
 CHANGELOG_FILE = ROOT / "CHANGELOG.md"
 METADATA_FILE = ROOT / "metadata.toml"
 STONECUTTER_FILE = ROOT / "stonecutter.json5"
+MATRIX_JOBS_FILE = CI / "matrix_jobs.toml"

--- a/ci/test/fixtures/bad_matrix_jobs.toml
+++ b/ci/test/fixtures/bad_matrix_jobs.toml
@@ -1,0 +1,3 @@
+[[build]]
+name = "broken"
+# missing gradle_args

--- a/ci/test/fixtures/edge_versions.json5
+++ b/ci/test/fixtures/edge_versions.json5
@@ -1,0 +1,15 @@
+// Valid with json5 edge-cases
+{
+  versions: {
+    "empty": [], // empty list
+    "null_version": null, // null value
+    "json5_features": [
+      "common:1.22.0",
+      "network:1.22.0",
+    ],
+    "mixed": [
+      "core:1.21",
+      {"project": "ui", "version": "1.21.1"},
+    ],
+  }
+}

--- a/ci/test/fixtures/empty_matrix_jobs.toml
+++ b/ci/test/fixtures/empty_matrix_jobs.toml
@@ -1,0 +1,1 @@
+hello = "world"

--- a/ci/test/fixtures/invalid_versions.json5
+++ b/ci/test/fixtures/invalid_versions.json5
@@ -1,0 +1,5 @@
+// Invalid versions objects
+{
+  "foo": 123,
+  // missing "versions" key
+}

--- a/ci/test/fixtures/matrix_jobs.toml
+++ b/ci/test/fixtures/matrix_jobs.toml
@@ -1,0 +1,7 @@
+[unknown]
+hello = "world"
+
+# Actual definition:
+[[build]]
+name = "test job 1"
+gradle_args = ["a", "b", "c"]

--- a/ci/test/fixtures/valid_versions.json5
+++ b/ci/test/fixtures/valid_versions.json5
@@ -1,0 +1,16 @@
+// Normal versions object
+{
+  versions: {
+    "1.21": ["common", "network"],
+    "1.20": ["common", "core", "ui"],
+    "1.19": [
+      {"project": "common"},
+      {"project": "fabric"},
+      {"project": "leather"}
+    ],
+    "1.18": [
+      "common:1.18.9",
+      "forge:1.18.9"
+    ]
+  }
+}

--- a/ci/test/test_build_matrix.py
+++ b/ci/test/test_build_matrix.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from freecam_ci.build_matrix import build_version_matrix, load_matrix_jobs, MatrixJob
+from freecam_ci.build_matrix import (
+    build_version_matrix,
+    load_matrix_jobs,
+    MatrixJob,
+    load_versions,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -60,26 +65,34 @@ def test_matrixjob_from_dict_upload_days_requires_upload():
         MatrixJob.from_dict(value)
 
 
+def test_load_versions_valid():
+    for fixture_name in ["valid_versions.json5", "edge_versions.json5"]:
+        path = FIXTURES / fixture_name
+        versions = load_versions(versions_file=path)
+        assert isinstance(versions, dict)
+        # basic structural checks
+        for key, value in versions.items():
+            assert isinstance(key, str)
+            assert value is None or isinstance(value, list)
+            if isinstance(value, list):
+                assert all(isinstance(v, (str, dict)) for v in value)
+
+
+def test_load_versions_invalid():
+    path = FIXTURES / "invalid_versions.json5"
+    # Invalid because the "versions" key is missing or schema doesn't match
+    with pytest.raises(Exception):
+        load_versions(versions_file=path)
+
+
 def test_build_version_matrix_basic():
-    data = {
-        "$schema": "123456",
-        "versions": {
-            "1.21": ["common", "network"],
-            "1.20": ["common", "core", "ui"],
-            "1.19": [
-                {"project": "common", "version": "1.19.2"},
-                {"project": "fabric", "version": "1.19.2"},
-                {"project": "leather", "version": "1.19.2"},
-            ],
-            "1.18": [
-                "common:1.18.9",
-                "forge:1.18.9",
-            ],
-        },
+    versions = {
+        "1.21": ["common", "network"],
+        "1.20": ["common", "core", "ui"],
     }
     version = "1.2.3"
-    matrix = build_version_matrix(version, data)
-    assert len(matrix) == 4
+    matrix = build_version_matrix(version, versions)
+    assert len(matrix) == 2
     names = [job.name for job in matrix]
     assert "Build 1.20" in names
     assert "Build 1.21" in names
@@ -91,19 +104,6 @@ def test_build_version_matrix_basic():
     assert job_120.upload_name == "freecam-1.2.3-1.20"
     assert job_120.upload_path == "build/libs/1.2.3/*.jar"
     assert all("common" not in arg for arg in job_120.gradle_args)
-
-    job_119 = next(job for job in matrix if job.name == "Build 1.19")
-    assert ":fabric:1.19:buildAndCollect" in job_119.gradle_args
-    assert ":leather:1.19:buildAndCollect" in job_119.gradle_args
-    assert job_119.upload_name == "freecam-1.2.3-1.19"
-    assert job_119.upload_path == "build/libs/1.2.3/*.jar"
-    assert all("common" not in arg for arg in job_119.gradle_args)
-
-    job_118 = next(job for job in matrix if job.name == "Build 1.18")
-    assert ":forge:1.18:buildAndCollect" in job_118.gradle_args
-    assert job_118.upload_name == "freecam-1.2.3-1.18"
-    assert job_118.upload_path == "build/libs/1.2.3/*.jar"
-    assert all("common" not in arg for arg in job_118.gradle_args)
 
 
 def test_load_matrix_jobs_empty():

--- a/ci/test/test_build_matrix.py
+++ b/ci/test/test_build_matrix.py
@@ -1,4 +1,10 @@
-from freecam_ci.build_matrix import build_matrix, MatrixJob
+from pathlib import Path
+
+import pytest
+
+from freecam_ci.build_matrix import build_version_matrix, load_matrix_jobs, MatrixJob
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def test_matrixjob_to_dict():
@@ -17,7 +23,44 @@ def test_matrixjob_to_dict():
     assert "upload_days" not in d
 
 
-def test_build_matrix_basic():
+def test_matrixjob_from_dict():
+    value = {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_path": "build/libs/*.jar",
+        "upload_name": "artifact",
+    }
+    job = MatrixJob.from_dict(value)
+    assert job == MatrixJob(
+        name="Build test",
+        gradle_args=[":common:test"],
+        upload_name="artifact",
+        upload_path="build/libs/*.jar",
+        upload_days=None,
+    )
+
+
+def test_matrixjob_from_dict_upload_pair_required():
+    value = {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_path": "build/libs/*.jar",
+    }
+    with pytest.raises(ValueError):
+        MatrixJob.from_dict(value)
+
+
+def test_matrixjob_from_dict_upload_days_requires_upload():
+    value = {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_days": 5,
+    }
+    with pytest.raises(ValueError):
+        MatrixJob.from_dict(value)
+
+
+def test_build_version_matrix_basic():
     data = {
         "$schema": "123456",
         "versions": {
@@ -35,12 +78,11 @@ def test_build_matrix_basic():
         },
     }
     version = "1.2.3"
-    matrix = build_matrix(version, data)
-    assert len(matrix) == 5
+    matrix = build_version_matrix(version, data)
+    assert len(matrix) == 4
     names = [job.name for job in matrix]
     assert "Build 1.20" in names
     assert "Build 1.21" in names
-    assert "Build logic tests" in names
 
     # Check gradle_args
     job_120 = next(job for job in matrix if job.name == "Build 1.20")
@@ -62,3 +104,24 @@ def test_build_matrix_basic():
     assert job_118.upload_name == "freecam-1.2.3-1.18"
     assert job_118.upload_path == "build/libs/1.2.3/*.jar"
     assert all("common" not in arg for arg in job_118.gradle_args)
+
+
+def test_load_matrix_jobs_empty():
+    matrix = load_matrix_jobs(matrix_jobs_file=FIXTURES / "empty_matrix_jobs.toml")
+    assert matrix == []
+
+
+def test_load_matrix_jobs():
+    matrix = load_matrix_jobs(matrix_jobs_file=FIXTURES / "matrix_jobs.toml")
+    assert len(matrix) == 1
+
+    assert matrix[0].name == "test job 1"
+    assert matrix[0].gradle_args == ["a", "b", "c"]
+    assert matrix[0].upload_name is None
+    assert matrix[0].upload_path is None
+    assert matrix[0].upload_days is None
+
+
+def test_load_matrix_jobs_invalid():
+    with pytest.raises(ValueError):
+        load_matrix_jobs(matrix_jobs_file=FIXTURES / "bad_matrix_jobs.toml")

--- a/ci/test/test_build_matrix.py
+++ b/ci/test/test_build_matrix.py
@@ -5,63 +5,10 @@ import pytest
 from freecam_ci.build_matrix import (
     build_version_matrix,
     load_matrix_jobs,
-    MatrixJob,
     load_versions,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
-
-
-def test_matrixjob_to_dict():
-    job = MatrixJob(
-        name="Build test",
-        gradle_args=[":common:test"],
-        upload_name=None,
-        upload_path="build/libs/*.jar",
-        upload_days=None,
-    )
-    assert job.to_dict() == {
-        "name": "Build test",
-        "gradle_args": [":common:test"],
-        "upload_path": "build/libs/*.jar",
-    }
-
-
-def test_matrixjob_from_dict():
-    value = {
-        "name": "Build test",
-        "gradle_args": [":common:test"],
-        "upload_path": "build/libs/*.jar",
-        "upload_name": "artifact",
-    }
-    job = MatrixJob.from_dict(value)
-    assert job == MatrixJob(
-        name="Build test",
-        gradle_args=[":common:test"],
-        upload_name="artifact",
-        upload_path="build/libs/*.jar",
-        upload_days=None,
-    )
-
-
-def test_matrixjob_from_dict_upload_pair_required():
-    value = {
-        "name": "Build test",
-        "gradle_args": [":common:test"],
-        "upload_path": "build/libs/*.jar",
-    }
-    with pytest.raises(ValueError):
-        MatrixJob.from_dict(value)
-
-
-def test_matrixjob_from_dict_upload_days_requires_upload():
-    value = {
-        "name": "Build test",
-        "gradle_args": [":common:test"],
-        "upload_days": 5,
-    }
-    with pytest.raises(ValueError):
-        MatrixJob.from_dict(value)
 
 
 def test_load_versions_valid():

--- a/ci/test/test_build_matrix.py
+++ b/ci/test/test_build_matrix.py
@@ -20,12 +20,11 @@ def test_matrixjob_to_dict():
         upload_path="build/libs/*.jar",
         upload_days=None,
     )
-    d = job.to_dict()
-    assert "name" in d
-    assert "gradle_args" in d
-    assert "upload_name" not in d
-    assert "upload_path" in d
-    assert "upload_days" not in d
+    assert job.to_dict() == {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_path": "build/libs/*.jar",
+    }
 
 
 def test_matrixjob_from_dict():

--- a/ci/test/test_matrix_model.py
+++ b/ci/test/test_matrix_model.py
@@ -1,0 +1,55 @@
+import pytest
+
+from freecam_ci.matrix_model import MatrixJob
+
+
+def test_matrixjob_to_dict():
+    job = MatrixJob(
+        name="Build test",
+        gradle_args=[":common:test"],
+        upload_name=None,
+        upload_path="build/libs/*.jar",
+        upload_days=None,
+    )
+    assert job.to_dict() == {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_path": "build/libs/*.jar",
+    }
+
+
+def test_matrixjob_from_dict():
+    value = {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_path": "build/libs/*.jar",
+        "upload_name": "artifact",
+    }
+    job = MatrixJob.from_dict(value)
+    assert job == MatrixJob(
+        name="Build test",
+        gradle_args=[":common:test"],
+        upload_name="artifact",
+        upload_path="build/libs/*.jar",
+        upload_days=None,
+    )
+
+
+def test_matrixjob_from_dict_upload_pair_required():
+    value = {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_path": "build/libs/*.jar",
+    }
+    with pytest.raises(ValueError):
+        MatrixJob.from_dict(value)
+
+
+def test_matrixjob_from_dict_upload_days_requires_upload():
+    value = {
+        "name": "Build test",
+        "gradle_args": [":common:test"],
+        "upload_days": 5,
+    }
+    with pytest.raises(ValueError):
+        MatrixJob.from_dict(value)

--- a/ci/test/test_stonecutter_model.py
+++ b/ci/test/test_stonecutter_model.py
@@ -1,0 +1,41 @@
+import pytest
+
+from freecam_ci.build_matrix import ProjectEntry
+
+
+def test_parse_string_entries():
+    entry = ProjectEntry.parse("core:1.20.1")
+    assert entry.project == "core"
+    assert entry.version == "1.20.1"
+    assert entry.buildscript is None
+
+    entry2 = ProjectEntry.parse("ui:1.20.2:custom_build")
+    assert entry2.project == "ui"
+    assert entry2.version == "1.20.2"
+    assert entry2.buildscript == "custom_build"
+
+
+def test_parse_dict_entries():
+    value = {"project": "fabric", "version": "1.19.2"}
+    entry = ProjectEntry.parse(value)
+    assert entry.project == "fabric"
+    assert entry.version == "1.19.2"
+    assert entry.buildscript is None
+
+
+def test_parse_invalid_entries():
+    with pytest.raises(ValueError):
+        # Incorrect type
+        # noinspection PyTypeChecker
+        ProjectEntry.parse(123)
+
+    with pytest.raises(ValueError):
+        ProjectEntry.parse({"version": "1.0"})  # missing 'project'
+
+
+def test_build_in_ci_property():
+    common_entry = ProjectEntry.parse("common:1.18")
+    assert common_entry.build_in_ci is False
+
+    other_entry = ProjectEntry.parse("core:1.20")
+    assert other_entry.build_in_ci is True


### PR DESCRIPTION
Introduce `ci/matrix_jobs.toml` for defining static matrix jobs; currently `:build-logic` tests.

This enables #354 to declaratively extend the matrix to build `:publish`, without needing to touch `ci/build_matrix`'s business logic.
