### PR TITLE
build: depend on `:common` properly

### DIFF
--- a/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 
 version = "${meta.loader}-${meta.version}+mc${meta.mc}"
-group = meta.group
 base {
     archivesName = meta.id
 }

--- a/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
@@ -4,15 +4,15 @@ plugins {
     id("freecam.common")
 }
 
-sourceSets {
-    main {
-        // Manually depend on common's pre-processed sources.
-        // NOTE: loaders have no build dependency on common, so API/implementation
-        //  classes and transitive dependencies must be manually propagated.
-        val commonTasks = commonNode.project.tasks
-        java.srcDirs(commonTasks.named<Sync>("stonecutterGenerate").map { it.destinationDir })
-        resources.srcDirs(commonTasks.processResources.map { it.destinationDir })
-    }
+dependencies {
+    implementation(commonNode.project)
+}
+
+tasks.processResources {
+    // We do some loader-specific processing in processResources...
+    // it's a little ugly that we add resources via `implementation` _and_ processResources
+    // FIXME: decide whether we will process in :common or loaders and stick to one
+    from(commonNode.project.tasks.processResources)
 }
 
 tasks.register<ProjectReleaseMetadataTask>("generateReleaseMetadata") {


### PR DESCRIPTION
Apparently setting `group` in gradle buildscripts has a bunch of undocumented pitfalls, that in our case confuse gradle and lead to unexpected dependency cycles when projects depend on other projects.

I was working around that by depending on `:common`'s sources, instead of the project's build artifacts.

Dropping `group = meta.group` in the convention plugin allows us to use a "normal" project dependency in the loader convention. This should mean that `:common` is compiled once, and the resulting classes are re-used by loader projects.