### PR TITLE
refactor(config): show a user-facing error screen when missing

### DIFF
--- a/common/src/main/java/net/xolt/freecam/config/ModBindings.java
+++ b/common/src/main/java/net/xolt/freecam/config/ModBindings.java
@@ -2,7 +2,6 @@ package net.xolt.freecam.config;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import net.minecraft.network.chat.Component;
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.gui.ConfigScreenProvider;
 import net.xolt.freecam.config.keys.FreecamKeyMapping;
@@ -14,7 +13,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static net.xolt.freecam.Freecam.MC;
 import static net.xolt.freecam.config.keys.FreecamKeyMappingBuilder.builder;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_F4;
 
@@ -32,13 +30,7 @@ public enum ModBindings {
             .holdAction(Freecam::resetTripodHandler)
             .build()),
     KEY_CONFIG_GUI(() -> builder("configGui")
-            .action(ConfigScreenProvider.provider()
-                    .map(provider -> (Runnable) provider::openConfigScreen)
-                    .orElseGet(() -> () -> {
-                        logger().info("Attempted to open config screen with no {} available", ConfigScreenProvider.class.getSimpleName());
-                        Optional.ofNullable(MC.player)
-                                .ifPresent(player -> player.displayClientMessage(Component.translatable(  "msg.freecam.configGuiMissing"), true));
-                    }))
+            .action(ConfigScreenProvider.provider()::openConfigScreen)
             .build());
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ModBindings.class);

--- a/common/src/main/java/net/xolt/freecam/config/gui/ConfigScreenProvider.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/ConfigScreenProvider.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.ServiceLoader.Provider;
 import java.util.stream.Collectors;
 
@@ -28,7 +27,7 @@ public interface ConfigScreenProvider {
         MC.setScreen(getConfigScreen(parent));
     }
 
-    static Optional<ConfigScreenProvider> provider() {
+    static ConfigScreenProvider provider() {
         return Holder.INSTANCE;
     }
 
@@ -36,7 +35,7 @@ public interface ConfigScreenProvider {
         private Holder() {}
 
         private static final Logger LOGGER = LoggerFactory.getLogger(ConfigScreenProvider.class);
-        private static final Optional<ConfigScreenProvider> INSTANCE;
+        private static final ConfigScreenProvider INSTANCE;
 
         static {
             // ConfigScreenProviders that are on the classpath.
@@ -52,12 +51,10 @@ public interface ConfigScreenProvider {
                     .map(Holder::attemptLoad)
                     .filter(Objects::nonNull)
                     .filter(provider -> !(provider instanceof OptionalProvider optional) || optional.isAvailable())
-                    .findFirst();
+                    .findFirst()
+                    .orElseGet(FallbackConfigScreenProvider::new);
 
-            INSTANCE.ifPresentOrElse(
-                    service -> LOGGER.info("Using {}", service.getName()),
-                    () -> LOGGER.info("No config screen provider available — GUI disabled")
-            );
+            LOGGER.info("Using {}", INSTANCE.getName());
         }
 
         private static @Nullable ConfigScreenProvider attemptLoad(Provider<ConfigScreenProvider> provider) {

--- a/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreen.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreen.java
@@ -1,0 +1,27 @@
+package net.xolt.freecam.config.gui;
+
+import net.minecraft.client.gui.screens.GenericMessageScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+final class FallbackConfigScreen extends GenericMessageScreen {
+
+    private static final Component TITLE = Component.translatable("text.freecam.missingConfigGui.title");
+
+    private final Screen parent;
+
+    FallbackConfigScreen(Screen parent) {
+        super(TITLE);
+        this.parent = parent;
+    }
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return true;
+    }
+
+    @Override
+    public void onClose() {
+        minecraft.setScreen(parent);
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreenProvider.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreenProvider.java
@@ -1,0 +1,16 @@
+package net.xolt.freecam.config.gui;
+
+import net.minecraft.client.gui.screens.Screen;
+
+final class FallbackConfigScreenProvider implements ConfigScreenProvider {
+
+    @Override
+    public Screen getConfigScreen(Screen parent) {
+        return new FallbackConfigScreen(parent);
+    }
+
+    @Override
+    public String getName() {
+        return "fallback screen";
+    }
+}

--- a/common/src/main/resources/assets/freecam/lang/en_us.json
+++ b/common/src/main/resources/assets/freecam/lang/en_us.json
@@ -10,7 +10,7 @@
   "msg.freecam.openTripod": "Opening camera %s",
   "msg.freecam.closeTripod": "Closing camera %s",
   "msg.freecam.tripodReset": "Reset camera %s",
-  "msg.freecam.configGuiMissing": "Cannot open Freecam Config GUI.",
+  "text.freecam.missingConfigGui.title": "Config GUI not available.",
   "text.autoconfig.freecam.title": "Freecam Options",
   "text.autoconfig.freecam.option.controls": "Key Bindings",
   "text.autoconfig.freecam.option.controls.@Tooltip": "Freecam key bindings.",

--- a/fabric/src/main/java/net/xolt/freecam/fabric/ModMenuIntegration.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/ModMenuIntegration.java
@@ -6,15 +6,11 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.xolt.freecam.config.gui.ConfigScreenProvider;
 
-import java.util.Optional;
-
 @Environment(EnvType.CLIENT)
 public class ModMenuIntegration implements ModMenuApi {
 
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        Optional<ConfigScreenFactory<?>> factory = ConfigScreenProvider.provider()
-                .map(provider -> provider::getConfigScreen);
-        return factory.orElseGet(ModMenuApi.super::getModConfigScreenFactory);
+        return ConfigScreenProvider.provider()::getConfigScreen;
     }
 }

--- a/forge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
+++ b/forge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
@@ -28,10 +28,10 @@ public class FreecamForge {
     public static void clientSetup(FMLClientSetupEvent event) {
         ModConfig.setup();
         // Register our config screen with Forge
-        ConfigScreenProvider.provider().ifPresent(provider -> ModLoadingContext.get().registerExtensionPoint(
+        ModLoadingContext.get().registerExtensionPoint(
                 ConfigScreenHandler.ConfigScreenFactory.class,
-                () -> new ConfigScreenHandler.ConfigScreenFactory((mc, parent) -> provider.getConfigScreen(parent))
-        ));
+                () -> new ConfigScreenHandler.ConfigScreenFactory((mc, parent) -> ConfigScreenProvider.provider().getConfigScreen(parent))
+        );
         //? forge: < 41 {
         /*ModBindings.forEach(ClientRegistry::registerKeyBinding);
         *///? }

--- a/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/FreecamForge.java
@@ -27,10 +27,10 @@ public class FreecamForge {
     public FreecamForge(ModContainer container) {
         ModConfig.setup();
         // Register our config screen with Forge
-        ConfigScreenProvider.provider().ifPresent(provider -> container.registerExtensionPoint(
+        container.registerExtensionPoint(
                 IConfigScreenFactory.class,
-                (_container, parent) -> provider.getConfigScreen(parent)
-        ));
+                (_container, parent) -> ConfigScreenProvider.provider().getConfigScreen(parent)
+        );
     }
 
 

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -55,6 +55,7 @@ stonecutter parameters {
         }
         string(current.parsed >= "1.20") {
             replace("canEnterPose(", "wouldNotSuffocateAtTargetPose(")
+            replace("GenericDirtMessageScreen", "GenericMessageScreen")
         }
         string(current.parsed >= "1.19") {
             replace("new net.minecraft.network.chat.TranslatableComponent(", "Component.translatable(")


### PR DESCRIPTION
Rather than skipping config screen registration when no provider is available, show a fallback screen with a user-facing error message.

This simplifies code, because we don't need to handle `Optional` presence.
This provides a better user experience, because they see that Freecam _can_ support configs, but currently does not.

We _could_ combine both systems; skip registering config support when no providers are loaded but show a fallback screen when some are loaded but none are "available" (have their dependencies loaded). This is the worst of both worlds in terms of complexity, though.

<img width="1808" height="1134" alt="image" src="https://github.com/user-attachments/assets/1f420a89-eb44-4761-a516-7deefe97405b" />


## Feature creep

Moved to #384
