### PR TITLE
build: use gradle content filtering

### DIFF
--- a/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
@@ -27,17 +27,53 @@ tasks.named<Jar>("jar") {
 }
 
 repositories {
-    mavenCentral()
-    maven("https://maven.parchmentmc.org/")
-    maven("https://maven.neoforged.net/releases/")
-    meta.deps.orNull("neoforge_pr")?.let {
-        maven {
-            url = uri("https://prmaven.neoforged.net/NeoForge/pr${it}")
-            content { includeModule("net.neoforged", "neoforge") }
+    meta.parchment { _, _ ->
+        exclusiveContent {
+            forRepository {
+                maven("https://maven.parchmentmc.org") { name = "Parchment" }
+            }
+            filter { includeGroup("org.parchmentmc.data") }
         }
     }
-    maven("https://maven.shedaniel.me/")
-    maven("https://maven.terraformersmc.com/")
+    maven("https://maven.neoforged.net/releases") {
+        name = "NeoForge"
+        content { includeGroup("net.neoforged") }
+    }
+    meta.deps.orNull("neoforge_pr").takeUnless { it.isNullOrBlank() }?.let {
+        exclusiveContent {
+            forRepository {
+                maven("https://prmaven.neoforged.net/NeoForge/pr$it") {
+                    name = "NeoForge PR#$it"
+                }
+            }
+            filter { includeModule("net.neoforged", "neoforge") }
+        }
+    }
+    exclusiveContent {
+        forRepository {
+            maven("https://maven.fabricmc.net") { name = "Fabric" }
+        }
+        filter { includeGroupAndSubgroups("net.fabricmc") }
+    }
+    exclusiveContent {
+        forRepository {
+            maven("https://repo.spongepowered.org/repository/maven-public") { name = "Sponge" }
+        }
+        filter { includeGroupAndSubgroups("org.spongepowered") }
+    }
+    exclusiveContent {
+        forRepository {
+            maven("https://maven.shedaniel.me") { name = "Shedaniel" }
+        }
+        filter { includeGroup("me.shedaniel.cloth") }
+    }
+    exclusiveContent {
+        forRepository {
+            maven("https://maven.terraformersmc.com") { name = "TerraformersMC" }
+        }
+        filter { includeGroup("com.terraformersmc") }
+    }
+    mavenCentral()
 }
 
 tasks.processResources {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -6,10 +6,15 @@ dependencyResolutionManagement {
         }
     }
     repositories {
-        mavenCentral()
+        exclusiveContent {
+            forRepositories(
+                maven("https://maven.kikugie.dev/releases") { name = "KikuGie" },
+                maven("https://maven.kikugie.dev/snapshots") { name = "KikuGie snapshots" },
+            )
+            filter { includeGroupAndSubgroups("dev.kikugie") }
+        }
         gradlePluginPortal()
-        maven("https://maven.kikugie.dev/snapshots")
-        maven("https://maven.fabricmc.net/")
+        mavenCentral()
     }
 }
 

--- a/build-logic/settings/build.gradle.kts
+++ b/build-logic/settings/build.gradle.kts
@@ -11,12 +11,6 @@ dependencies {
     implementation(libs.kotlin.serialization.toml)
 }
 
-repositories {
-    mavenCentral()
-    gradlePluginPortal()
-    maven("https://maven.kikugie.dev/snapshots")
-}
-
 gradlePlugin {
     plugins {
         create("modMetadata") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,13 +5,30 @@ gradle.startParameter.isConfigureOnDemand = !isCi
 
 pluginManagement {
     repositories {
+        exclusiveContent {
+            forRepository {
+                maven("https://maven.fabricmc.net") { name = "Fabric" }
+            }
+            filter {
+                includeGroup("fabric-loom")
+                includeGroupAndSubgroups("net.fabricmc")
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                maven("https://maven.neoforged.net/releases") { name = "Neoforge" }
+            }
+            filter { includeGroupAndSubgroups( "net.neoforged") }
+        }
+        exclusiveContent {
+            forRepositories(
+                maven("https://maven.kikugie.dev/releases") { name = "KikuGie" },
+                maven("https://maven.kikugie.dev/snapshots") { name = "KikuGie snapshots" },
+            )
+            filter { includeGroupAndSubgroups("dev.kikugie") }
+        }
         gradlePluginPortal()
         mavenCentral()
-        maven("https://maven.fabricmc.net/")
-        maven("https://maven.neoforged.net/releases/")
-        maven("https://maven.minecraftforge.net")
-        maven("https://maven.kikugie.dev/snapshots")
-        maven("https://maven.kikugie.dev/releases")
     }
     includeBuild("build-logic")
 }


### PR DESCRIPTION
Explicitly tell Gradle where to look for dependencies, to speed up builds and prevent spamming repos for unrelated libs.
