### PR TITLE
[WIP] improve fallback config screen

### DIFF
--- a/cloth-config/src/main/java/net/xolt/freecam/clothconfig/ClothConfigScreenProvider.java
+++ b/cloth-config/src/main/java/net/xolt/freecam/clothconfig/ClothConfigScreenProvider.java
@@ -3,6 +3,7 @@ package net.xolt.freecam.clothconfig;
 import net.minecraft.client.gui.screens.Screen;
 import net.xolt.freecam.config.controller.ConfigControllerRegistry;
 import net.xolt.freecam.config.gui.ConfigScreenProvider;
+import net.xolt.freecam.config.gui.DependencyDescription;
 import net.xolt.freecam.config.gui.OptionalProvider;
 import net.xolt.freecam.config.model.ModConfigDTO;
 import org.jetbrains.annotations.Nullable;
@@ -10,6 +11,8 @@ import org.jetbrains.annotations.Nullable;
 import static java.lang.Thread.currentThread;
 
 public class ClothConfigScreenProvider implements ConfigScreenProvider, OptionalProvider {
+
+    public static final DependencyDescription REQUIREMENTS = new DependencyDescription.Literal("Cloth Config");
 
     private @Nullable ModConfigScreenFactory factory;
 
@@ -44,5 +47,10 @@ public class ClothConfigScreenProvider implements ConfigScreenProvider, Optional
         } catch (ClassNotFoundException | LinkageError e) {
             return false;
         }
+    }
+
+    @Override
+    public DependencyDescription getRequirement() {
+        return REQUIREMENTS;
     }
 }

--- a/common/src/main/java/net/xolt/freecam/config/gui/ConfigScreenProvider.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/ConfigScreenProvider.java
@@ -52,7 +52,14 @@ public interface ConfigScreenProvider {
                     .filter(Objects::nonNull)
                     .filter(provider -> !(provider instanceof OptionalProvider optional) || optional.isAvailable())
                     .findFirst()
-                    .orElseGet(FallbackConfigScreenProvider::new);
+                    .orElseGet(() -> new FallbackConfigScreenProvider(
+                            providers.stream()
+                                    .filter(provider -> OptionalProvider.class.isAssignableFrom(provider.type()))
+                                    .map(Holder::attemptLoad)
+                                    .filter(Objects::nonNull)
+                                    .map(OptionalProvider.class::cast)
+                                    .toList()
+                    ));
 
             LOGGER.info("Using {}", INSTANCE.getName());
         }

--- a/common/src/main/java/net/xolt/freecam/config/gui/DependencyDescription.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/DependencyDescription.java
@@ -1,0 +1,13 @@
+package net.xolt.freecam.config.gui;
+
+import java.util.Collections;
+import java.util.List;
+
+public /*? if java: >=17 >>*/sealed interface DependencyDescription {
+    record Literal(String text) implements DependencyDescription {}
+    record Translatable(String key, List<?> args) implements DependencyDescription {
+        public Translatable(String key) {
+            this(key, Collections.emptyList());
+        }
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreen.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreen.java
@@ -4,15 +4,43 @@ import net.minecraft.client.gui.screens.GenericMessageScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
+import java.util.Collection;
+import java.util.List;
+
 final class FallbackConfigScreen extends GenericMessageScreen {
 
     private static final Component TITLE = Component.translatable("text.freecam.missingConfigGui.title");
 
     private final Screen parent;
+    private final List<Component> requirementText;
 
-    FallbackConfigScreen(Screen parent) {
+    FallbackConfigScreen(Screen parent, Collection<OptionalProvider> supportedProviders) {
         super(TITLE);
         this.parent = parent;
+        requirementText = supportedProviders.stream()
+                .map(provider -> renderRequirement(provider.getRequirement()))
+                .toList();
+    }
+
+    private static Component renderRequirement(DependencyDescription requirement) {
+        //? if java: >=21 {
+        return switch (requirement) {
+            case DependencyDescription.Literal literal -> renderRequirement(literal);
+            case DependencyDescription.Translatable translatable -> renderRequirement(translatable);
+        };
+        //? } else {
+        /*if (requirement instanceof DependencyDescription.Literal literal) return renderRequirement(literal);
+        if (requirement instanceof DependencyDescription.Translatable translatable) return renderRequirement(translatable);
+        throw new IllegalStateException();
+        *///? }
+    }
+
+    private static Component renderRequirement(DependencyDescription.Literal requirement) {
+        return Component.literal(requirement.text());
+    }
+
+    private static Component renderRequirement(DependencyDescription.Translatable requirement) {
+        return Component.translatable(requirement.key(), requirement.args().toArray());
     }
 
     @Override

--- a/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreenProvider.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/FallbackConfigScreenProvider.java
@@ -2,11 +2,19 @@ package net.xolt.freecam.config.gui;
 
 import net.minecraft.client.gui.screens.Screen;
 
+import java.util.Collection;
+
 final class FallbackConfigScreenProvider implements ConfigScreenProvider {
+
+    private final Collection<OptionalProvider> supportedProviders;
+
+    public FallbackConfigScreenProvider(Collection<OptionalProvider> supportedProviders) {
+        this.supportedProviders = supportedProviders;
+    }
 
     @Override
     public Screen getConfigScreen(Screen parent) {
-        return new FallbackConfigScreen(parent);
+        return new FallbackConfigScreen(parent, supportedProviders);
     }
 
     @Override

--- a/common/src/main/java/net/xolt/freecam/config/gui/OptionalProvider.java
+++ b/common/src/main/java/net/xolt/freecam/config/gui/OptionalProvider.java
@@ -2,4 +2,5 @@ package net.xolt.freecam.config.gui;
 
 public interface OptionalProvider {
     boolean isAvailable();
+    DependencyDescription getRequirement();
 }


### PR DESCRIPTION
Split from #380

## Feature creep

- [x] #380
- [ ] Add a button to open config file, for manual editing
- [ ] Add ways to reload config file
  - button, open screen, close screen?
  - nio `WatchService` thread?
- [ ] List "supported" (loaded) providers
  - Rendered as a list of "config screen library" mods we support
  - WIP in this branch

