### PR TITLE
chore: release 1.4.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,14 @@ This version includes major underlying changes. Feedback and bug reports are gre
 
 - Releases are now built for multiple supported Minecraft versions from a single codebase ([366](https://github.com/MinecraftFreecam/Freecam/pull/366))
   - Migrated from [Architectury](https://docs.architectury.dev) to [Stonecutter](https://stonecutter.kikugie.dev)
+  - While there should be no change in behavior, there were **many internal changes** throughout the project
 - Config file renamed from `freecam.json5` to `freecam.json` ([376](https://github.com/MinecraftFreecam/Freecam/pull/376))
   - Existing `freecam.json5` configs are read when `freecam.json` isn't present
-  - All changes are saved to `freecam.json`
-- Cloth Config is now optional at runtime ([378](https://github.com/MinecraftFreecam/Freecam/pull/378))
-  - Config GUI is only available when Cloth Config is present
-  - A bundled Cloth Config distribution is still included in most builds
-- Refactor config system internals ([373](https://github.com/MinecraftFreecam/Freecam/pull/373), [374](https://github.com/MinecraftFreecam/Freecam/pull/374), [377](https://github.com/MinecraftFreecam/Freecam/pull/377))
-  - Separated Cloth Config GUI from the core config system
-- Refactor collision filtering logic ([375](https://github.com/MinecraftFreecam/Freecam/pull/375))
+  - All new changes are saved to `freecam.json`
+- Cloth Config is _technically_ now optional at runtime ([378](https://github.com/MinecraftFreecam/Freecam/pull/378))
+  - The config GUI is only available when Cloth Config is loaded
+  - A bundled Cloth Config distribution is **still included** in most builds
+- Refactored several config system internals ([373](https://github.com/MinecraftFreecam/Freecam/pull/373), [374](https://github.com/MinecraftFreecam/Freecam/pull/374), [375](https://github.com/MinecraftFreecam/Freecam/pull/375), [377](https://github.com/MinecraftFreecam/Freecam/pull/377))
 - Various translation updates
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+## [1.4.0-alpha.1] - 2026-03-31
+
+This version includes major underlying changes. Feedback and bug reports are greatly appreciated!
+**[Bug tracker](https://github.com/MinecraftFreecam/Freecam/issues).**
+
+### Added
+
 - 26.1 support ([370](https://github.com/MinecraftFreecam/Freecam/pull/370))
 
 ### Changed
@@ -24,8 +37,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 - Refactor config system internals ([373](https://github.com/MinecraftFreecam/Freecam/pull/373), [374](https://github.com/MinecraftFreecam/Freecam/pull/374), [377](https://github.com/MinecraftFreecam/Freecam/pull/377))
   - Separated Cloth Config GUI from the core config system
 - Refactor collision filtering logic ([375](https://github.com/MinecraftFreecam/Freecam/pull/375))
-
-### Removed
+- Various translation updates
 
 ### Fixed
 
@@ -620,7 +632,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 - Minecraft 1.18 support.
 - Minecraft 1.17 support.
 
-[Unreleased]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.6...HEAD
+[Unreleased]: https://github.com/MinecraftFreecam/Freecam/compare/v1.4.0-alpha.1...HEAD
+[1.4.0-alpha.1]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.6...v1.4.0-alpha.1
 [1.3.6]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.3...v1.3.4

--- a/metadata.toml
+++ b/metadata.toml
@@ -4,7 +4,7 @@ id = "freecam"
 group = "net.xolt.freecam"
 # Version can specify a semver pre-release, e.g. -alpha.1
 # Remember to run `:patchChangelog` when updating
-version = "1.3.6"
+version = "1.4.0-alpha.1"
 authors = ["hashalite", "Matt Sturgeon"]
 description = "A highly customizable freecam mod."
 license = "MIT"


### PR DESCRIPTION
Release an alpha build of the major stonecutter port, 26.1 support, config system changes, etc.

It'd be good to have a stable release soon, but more testing is needed.

I tested locally how the `patchChangelog` task will handle going from a pre-release (1.4.0-alpha-1) to a full-release (1.4.0):
intuitively, any 1.4.0 pre-release changelog entries will get combined into a single 1.4.0 entry.

~~Needs #388 for `-alpha.1` format support~~

----

## Testing

Build artifacts are available on the latest workflow run: [run#23790450684](https://github.com/MinecraftFreecam/Freecam/actions/runs/23790450684?pr=385), [run#23792281483](https://github.com/MinecraftFreecam/Freecam/actions/runs/23792281483?pr=385)

**I've not yet tested these exact build artifacts in production,** but this is marked as an alpha release...

## Changelog

This version includes major underlying changes. Feedback and bug reports are greatly appreciated!
**[Bug tracker](https://github.com/MinecraftFreecam/Freecam/issues).**

### Added

- 26.1 support ([370](https://github.com/MinecraftFreecam/Freecam/pull/370))

### Changed

- Releases are now built for multiple supported Minecraft versions from a single codebase ([366](https://github.com/MinecraftFreecam/Freecam/pull/366))
  - Migrated from [Architectury](https://docs.architectury.dev) to [Stonecutter](https://stonecutter.kikugie.dev)
  - While there should be no change in behavior, there were **many internal changes** throughout the project
- Config file renamed from `freecam.json5` to `freecam.json` ([376](https://github.com/MinecraftFreecam/Freecam/pull/376))
  - Existing `freecam.json5` configs are read when `freecam.json` isn't present
  - All new changes are saved to `freecam.json`
- Cloth Config is _technically_ now optional at runtime ([378](https://github.com/MinecraftFreecam/Freecam/pull/378))
  - The config GUI is only available when Cloth Config is loaded
  - A bundled Cloth Config distribution is **still included** in most builds
- Refactored several config system internals ([373](https://github.com/MinecraftFreecam/Freecam/pull/373), [374](https://github.com/MinecraftFreecam/Freecam/pull/374), [375](https://github.com/MinecraftFreecam/Freecam/pull/375), [377](https://github.com/MinecraftFreecam/Freecam/pull/377))
- Various translation updates

### Fixed

- Config options from other Freecam versions are no longer silently dropped when saving ([389](https://github.com/MinecraftFreecam/Freecam/pull/389))


