### PR TITLE
build(meta): derive ReleaseType from semantic version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,14 +88,6 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ## [1.3.0] - 2024-07-27
 
-### Fixed
-
-- Config is now initialized before config screen is registered (fixes [#234](https://github.com/MinecraftFreecam/Freecam/issues/234))
-- Build against NeoForge 21.0.139-beta (fixes opening config screen through Forge modlist crashing)
-- Pumpkin overlay rendering while Freecam is enabled ([#239](https://github.com/MinecraftFreecam/Freecam/issues/239))
-
-## [1.3.0-beta1] - 2024-06-13
-
 ### Added
 
 - 1.21 Support ([#222](https://github.com/MinecraftFreecam/Freecam/pull/222)).
@@ -106,6 +98,12 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 - Issues specific to hosting LAN worlds ([#207](https://github.com/MinecraftFreecam/Freecam/pull/207)).
   - Compatibility issue with Lunar Client ([#206](https://github.com/MinecraftFreecam/Freecam/issues/206)).
   - Modrinth Edition not treating hosted LAN worlds as singleplayer.
+
+### Fixed after beta1
+
+- Config is now initialized before config screen is registered (fixes [#234](https://github.com/MinecraftFreecam/Freecam/issues/234))
+- Build against NeoForge 21.0.139-beta (fixes opening config screen through Forge modlist crashing)
+- Pumpkin overlay rendering while Freecam is enabled ([#239](https://github.com/MinecraftFreecam/Freecam/issues/239))
 
 ## [1.2.4] - 2024-04-23
 
@@ -627,8 +625,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 [1.3.3]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.0-beta1...v1.3.0
-[1.3.0-beta1]: https://github.com/MinecraftFreecam/Freecam/compare/v1.2.4...v1.3.0-beta1
+[1.3.0]: https://github.com/MinecraftFreecam/Freecam/compare/v1.2.4...v1.3.0
 [1.2.4]: https://github.com/MinecraftFreecam/Freecam/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/MinecraftFreecam/Freecam/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/MinecraftFreecam/Freecam/compare/v1.2.1.1...v1.2.2

--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
@@ -1,5 +1,6 @@
 package net.xolt.freecam.model
 
+import io.github.z4kn4fein.semver.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -50,8 +51,6 @@ data class ModMetadataToml(
     override val name: String,
     override val group: String,
     override val version: String,
-    @SerialName("release_type")
-    override val releaseType: ReleaseType,
     override val authors: List<String>,
     override val description: String,
     override val license: String,
@@ -73,4 +72,13 @@ data class ModMetadataToml(
     override val modrinthId: String,
     @SerialName("crowdin")
     override val crowdinUrl: UrlString,
-) : StaticModMetadata
+) : StaticModMetadata {
+
+    private val semver: Version by lazy {
+        Version.parse(version, strict = false)
+    }
+
+    override val releaseType: ReleaseType by lazy {
+        semver.toReleaseType()
+    }
+}

--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ReleaseType.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ReleaseType.kt
@@ -1,7 +1,12 @@
 package net.xolt.freecam.model
 
+import io.github.z4kn4fein.semver.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
 
 @Serializable
 enum class ReleaseType {
@@ -10,3 +15,27 @@ enum class ReleaseType {
     @SerialName("beta") BETA,
     @SerialName("alpha") ALPHA
 }
+
+/** Extract a [ReleaseType] from a semantic version string. */
+fun ReleaseType.Companion.fromVersion(version: String, strict: Boolean = false): ReleaseType =
+    Version.parse(version, strict).toReleaseType()
+
+/** Extract a [ReleaseType] from a [Version]. */
+internal fun Version.toReleaseType(): ReleaseType =
+    preRelease
+        ?.substringBefore('.')
+        ?.toReleaseType()
+        ?.also {
+            require(it != ReleaseType.RELEASE) {
+                "Semver pre-release label '$preRelease' resolved to RELEASE: not a pre-release type"
+            }
+        }
+        ?: ReleaseType.RELEASE
+
+/** Parse a string into a ReleaseType. */
+fun String.toReleaseType(): ReleaseType =
+    try {
+        Json.decodeFromJsonElement(Json.encodeToJsonElement(this))
+    } catch (_: SerializationException) {
+        throw IllegalArgumentException("Invalid ReleaseType: $this")
+    }

--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ReleaseType.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ReleaseType.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class ReleaseType {
     @SerialName("release") RELEASE,
+    @SerialName("rc") RELEASE_CANDIDATE,
     @SerialName("beta") BETA,
     @SerialName("alpha") ALPHA
 }

--- a/build-logic/api/src/test/kotlin/net/xolt/freecam/model/ModMetadataTomlTest.kt
+++ b/build-logic/api/src/test/kotlin/net/xolt/freecam/model/ModMetadataTomlTest.kt
@@ -1,0 +1,53 @@
+package net.xolt.freecam.model
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ModMetadataTomlTest {
+
+    @Test
+    fun `releaseType derived from stable version`() {
+        val meta = metadata(version = "1.3.6")
+        meta.releaseType shouldBe ReleaseType.RELEASE
+    }
+
+    @Test
+    fun `releaseType derived from preRelease version`() {
+        listOf(
+            "2"   to ReleaseType.RELEASE,
+            "2.0"   to ReleaseType.RELEASE,
+            "2.0.0" to ReleaseType.RELEASE,
+            "2.0.0-alpha" to ReleaseType.ALPHA,
+            "2.0.0-beta" to ReleaseType.BETA,
+            "2.0.0-rc"   to ReleaseType.RELEASE_CANDIDATE,
+            "2.0.0-alpha.1" to ReleaseType.ALPHA,
+            "2.0.0-beta.2" to ReleaseType.BETA,
+            "2.0.0-rc.1"   to ReleaseType.RELEASE_CANDIDATE,
+            "2.0-beta" to ReleaseType.BETA,
+            "2.0-rc.1"   to ReleaseType.RELEASE_CANDIDATE,
+        ).forEach { (version, expected) ->
+            metadata(version = version).releaseType shouldBe expected
+        }
+    }
+
+    private fun metadata(version: String) = ModMetadataToml(
+        id = "",
+        name = "",
+        group = "",
+        version = version,
+        authors = emptyList(),
+        description = "",
+        license = "",
+        homepageUrl = url(),
+        sourceUrl = url(),
+        issuesUrl = url(),
+        githubReleasesUrl = url(),
+        curseforgeUrl = url(),
+        curseforgeId = "",
+        modrinthUrl = url(),
+        modrinthId = "",
+        crowdinUrl = url(),
+    )
+
+    private fun url(url: String = "https://example.com") = UrlString(url)
+}

--- a/build-logic/api/src/test/kotlin/net/xolt/freecam/model/ReleaseTypeTest.kt
+++ b/build-logic/api/src/test/kotlin/net/xolt/freecam/model/ReleaseTypeTest.kt
@@ -1,0 +1,74 @@
+package net.xolt.freecam.model
+
+import io.github.z4kn4fein.semver.Version
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class ReleaseTypeTest {
+
+    @Test
+    fun `String toReleaseType`() {
+        listOf(
+            // "release" is a valid ReleaseType serial name,
+            // even though it's not a valid pre-release label
+            "release" to ReleaseType.RELEASE,
+            "rc" to ReleaseType.RELEASE_CANDIDATE,
+            "beta" to ReleaseType.BETA,
+            "alpha" to ReleaseType.ALPHA,
+        ).forEach { (input, expected) ->
+            val result = input.toReleaseType()
+            result shouldBe expected
+        }
+    }
+
+    @Test
+    fun `Version toReleaseType`() {
+        listOf(
+            Version() to ReleaseType.RELEASE,
+            Version(preRelease = "rc") to ReleaseType.RELEASE_CANDIDATE,
+            Version(preRelease = "beta") to ReleaseType.BETA,
+            Version(preRelease = "alpha") to ReleaseType.ALPHA,
+            Version(preRelease = "rc.1")   to ReleaseType.RELEASE_CANDIDATE,
+            Version(preRelease = "beta.2") to ReleaseType.BETA,
+            Version(preRelease = "alpha.1") to ReleaseType.ALPHA,
+        ).forEach { (input, expected) ->
+            val result = input.toReleaseType()
+            result shouldBe expected
+        }
+    }
+
+    @Test
+    fun `String toReleaseType - invalid string throws`() {
+        listOf(
+            "",
+            "stable",
+            "pre",
+            "snapshot",
+            "1.0",
+            "rc.1",
+            "beta.2",
+            "alpha.1",
+        ).forEach { input ->
+            shouldThrow<IllegalArgumentException> {
+                input.toReleaseType()
+            }
+        }
+    }
+
+    @Test
+    fun `Version toReleaseType - unrecognised pre-release label throws`() {
+        listOf("release", "snapshot", "nightly", "pre", "stable").forEach { label ->
+            shouldThrow<IllegalArgumentException> {
+                Version(preRelease = label).toReleaseType()
+            }
+        }
+    }
+
+    @Test
+    fun `String and Version toReleaseType agree`() {
+        listOf("rc", "beta", "alpha").forEach { label ->
+            label.toReleaseType() shouldBe Version(preRelease = label).toReleaseType()
+        }
+    }
+}

--- a/metadata.toml
+++ b/metadata.toml
@@ -3,6 +3,7 @@ name = "Freecam"
 id = "freecam"
 group = "net.xolt.freecam"
 # Version can specify a semver pre-release, e.g. -alpha.1
+# Remember to run `:patchChangelog` when updating
 version = "1.3.6"
 authors = ["hashalite", "Matt Sturgeon"]
 description = "A highly customizable freecam mod."

--- a/metadata.toml
+++ b/metadata.toml
@@ -2,8 +2,8 @@
 name = "Freecam"
 id = "freecam"
 group = "net.xolt.freecam"
+# Version can specify a semver pre-release, e.g. -alpha.1
 version = "1.3.6"
-release_type = "release" # alpha, beta, release
 authors = ["hashalite", "Matt Sturgeon"]
 description = "A highly customizable freecam mod."
 license = "MIT"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -109,7 +109,7 @@ changelog {
 
     // Regex used to find versions in headings.
     // The default regex only supports semantic versions, this one is more lenient.
-    headerParserRegex = Regex("(\\d+(?:\\.\\d+)+(?:-[-a-z]+\\d*)?)")
+    headerParserRegex = Regex("(\\d+(?:\\.\\d+)+(?:-[-a-z]+(?:\\.\\d+)?)?)")
 }
 
 tasks.generateReleaseMetadata {


### PR DESCRIPTION

Automatically derive the ReleaseType from the (semantic) version, as follows:
- `1.0.0-alpha.1` → `ALPHA`
- `1.0.0-beta.1` → `BETA`
- `1.0.0-rc.1` → `RELEASE_CANDIDATE`
- `1.0.0` → `RELEASE`

Also, adds a `:patchChangelog` reminder comment in `metadata.toml` and adds `ReleaseType.RELEASE_CANDIDATE` (`rc`) support.

Also collapsed the only changelog entry using `-beta1` format, and updated the changelog regex to expect `-beta` or `-beta.1` instead.