### PR TITLE
feat(config): preserve unknown keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- Config options from other Freecam versions are no longer silently dropped when saving ([389](https://github.com/MinecraftFreecam/Freecam/pull/389))
+
 ## [1.3.6] - 2025-12-20
 
 ### Added

--- a/common/src/main/java/net/xolt/freecam/config/model/GsonConfigLoader.java
+++ b/common/src/main/java/net/xolt/freecam/config/model/GsonConfigLoader.java
@@ -1,7 +1,6 @@
 package net.xolt.freecam.config.model;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.gson.*;
 import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map.Entry;
 
 public class GsonConfigLoader<T> implements ConfigLoader<T> {
 
@@ -34,25 +34,27 @@ public class GsonConfigLoader<T> implements ConfigLoader<T> {
 
     @Override
     public void write(T config) throws Exception {
+        JsonObject current = gson.toJsonTree(config).getAsJsonObject();
+        JsonObject previous = config instanceof RawJsonHolder holder ? holder.getRawJson() : null;
+        JsonObject merged = previous == null ? current : merge(current, previous);
+
         Files.createDirectories(filepath.getParent());
         try (BufferedWriter writer = Files.newBufferedWriter(filepath)) {
-            gson.toJson(config, writer);
+            gson.toJson(merged, writer);
         }
     }
 
     @Override
     public T read() throws Exception {
         if (Files.exists(filepath)) {
-            try (BufferedReader reader = Files.newBufferedReader(filepath)) {
-                return gson.fromJson(reader, configClass);
-            }
+            return load(filepath);
         }
 
         // Attempt to migrate old .json5 configs to .json
         if (Files.exists(legacyFilepath)) {
             LOGGER.info("{} not found, attempting to migrate legacy config {}", filepath.getFileName(), legacyFilepath.getFileName());
-            try (BufferedReader reader = Files.newBufferedReader(legacyFilepath)) {
-                return gson.fromJson(reader, configClass);
+            try {
+                return load(legacyFilepath);
             } catch (Exception e) {
                 LOGGER.warn("Failed to migrate legacy config {}, falling back to defaults", legacyFilepath.getFileName(), e);
             }
@@ -60,5 +62,56 @@ public class GsonConfigLoader<T> implements ConfigLoader<T> {
 
         // Return defaults if no config file exists
         return configClass.getConstructor().newInstance();
+    }
+
+    private T load(Path path) throws Exception {
+        JsonObject rawJson;
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            //~ if gson: >=2.8.6 'new JsonParser().parse' -> 'JsonParser.parseReader'
+            rawJson = JsonParser.parseReader(reader).getAsJsonObject();
+        }
+        T result = gson.fromJson(rawJson, configClass);
+        if (result instanceof RawJsonHolder holder) {
+            holder.setRawJson(rawJson);
+        }
+        return result;
+    }
+
+    /**
+     * Recursively preserve unknown fields from unrecognized config versions.
+     * <p>
+     * Merges keys from {@code previous} unless they are already present in {@code current}.
+     * <p>
+     * Merges recursively when both sides have a {@link JsonObject} at the same key.
+     * Non-object fields present in {@code current} are always kept, taking precedence over conflicting fields in
+     * {@code previous}.
+     *
+     * @return a new {@link JsonObject}
+     */
+    private JsonObject merge(JsonObject current, JsonObject previous) {
+        JsonObject result = deepCopy(current).getAsJsonObject();
+        for (Entry<String, JsonElement> entry : previous.entrySet()) {
+            String key = entry.getKey();
+            JsonElement previousValue = entry.getValue();
+            JsonElement currentValue = current.get(key);
+
+            if (currentValue == null) {
+                // Unknown key: use previous value
+                result.add(key, deepCopy(previousValue));
+            } else if (currentValue.isJsonObject() && previousValue.isJsonObject()) {
+                // Nested objects: merge recursively
+                JsonObject object = merge(currentValue.getAsJsonObject(), previousValue.getAsJsonObject());
+                result.add(key, object);
+            }
+            // Otherwise: current overwrites previous value
+        }
+        return result;
+    }
+
+    private JsonElement deepCopy(JsonElement element) {
+        //? if gson: >=2.8.2 {
+        return element.deepCopy();
+        //? } else
+        //return gson.fromJson(gson.toJson(element), JsonElement.class);
     }
 }

--- a/common/src/main/java/net/xolt/freecam/config/model/ModConfigDTO.java
+++ b/common/src/main/java/net/xolt/freecam/config/model/ModConfigDTO.java
@@ -1,15 +1,18 @@
 package net.xolt.freecam.config.model;
 
+import com.google.gson.JsonObject;
 import net.minecraft.world.level.block.Block;
 import net.xolt.freecam.config.MCAwareModConfig;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
 // TODO: separate DTO from domain model
 // move CollisionBehavior and ModConfig-impl to domain model adapter
-public class ModConfigDTO implements MCAwareModConfig {
+public class ModConfigDTO implements MCAwareModConfig, RawJsonHolder {
 
+    private transient @Nullable JsonObject rawJson;
     private transient CollisionPredicate collisionPredicate;
 
     public ModConfigDTO() {
@@ -18,6 +21,16 @@ public class ModConfigDTO implements MCAwareModConfig {
 
     public void onConfigChange() {
         collisionPredicate = CollisionPredicate.create(collision);
+    }
+
+    @Override
+    public void setRawJson(@Nullable JsonObject rawJson) {
+        this.rawJson = rawJson;
+    }
+
+    @Override
+    public @Nullable JsonObject getRawJson() {
+        return rawJson;
     }
 
     @Override

--- a/common/src/main/java/net/xolt/freecam/config/model/RawJsonHolder.java
+++ b/common/src/main/java/net/xolt/freecam/config/model/RawJsonHolder.java
@@ -1,0 +1,9 @@
+package net.xolt.freecam.config.model;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.Nullable;
+
+public interface RawJsonHolder {
+    void setRawJson(JsonObject rawJson);
+    @Nullable JsonObject getRawJson();
+}

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -40,6 +40,17 @@ stonecutter parameters {
         else -> JavaVersion.VERSION_1_8
     }.majorVersion
 
+    dependencies["gson"] = when {
+        current.parsed >= "1.21.11" -> "2.13.2"
+        current.parsed >= "1.21.4" -> "2.11.0"
+        current.parsed >= "1.20.2" -> "2.10.1"
+        current.parsed >= "1.19.3" -> "2.10"
+        current.parsed >= "1.18.2" -> "2.8.9"
+        current.parsed >= "1.18" -> "2.8.8"
+        current.parsed >= "1.12" -> "2.8.0"
+        else -> "2.2.4"
+    }
+
     // Experimental cloth-config dependencies API added in v8.4
     // Forward-ported to newer versions but not backported to older versions.
     constants["cloth_dependencies"] = sc.eval(meta.deps["cloth"], ">=8.4")


### PR DESCRIPTION
Freecam typically uses the same config file across versions, which can lead to data loss when a config file contains keys written by a different mod version that the current version doesn't know about.

Solve this by deserializing both a raw `JsonObject` tree and a typesafe config DTO. When re-serializing, we merge any keys present in the original JSON but absent from the DTO-derived output, preserving unknown fields across round-trips.

<img width="214" height="173" alt="image" src="https://github.com/user-attachments/assets/a367a747-9fb8-4522-abdd-ae64a4c4df40" />

See #379
