### PR TITLE
ci: cleanup names and concurrency groups

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,12 @@ on:
   push:
   pull_request:
 
-# Only allow running one build per branch at a time to optimise cache hits
+# Group workflow runs by event and ref.
+# New runs cancel any pending run.
+# PR runs also cancel in-progress runs.
 concurrency:
-  group: builds-${{ github.ref }}
+  group: build-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 permissions: {}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   prepare:
+    name: Setup
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Checks
 
 on:
   pull_request:
@@ -7,14 +7,15 @@ on:
 # New runs cancel any pending run.
 # In-progress runs are allowed to complete.
 concurrency:
-  group: lint-${{ github.ref }}
+  group: check-${{ github.ref }}
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  lint:
+  validate:
+    name: Validation
     runs-on: ubuntu-slim
     timeout-minutes: 30
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,6 +3,12 @@ name: Lint
 on:
   pull_request:
 
+# Group workflow runs by ref.
+# New runs cancel any pending run.
+# In-progress runs are allowed to complete.
+concurrency:
+  group: lint-${{ github.ref }}
+
 defaults:
   run:
     shell: bash

--- a/ci/matrix_jobs.toml
+++ b/ci/matrix_jobs.toml
@@ -1,5 +1,5 @@
 [[build]]
-name = "Build logic tests"
+name = "Tooling"
 gradle_args = ["--project-dir", "build-logic", ":check"]
 
 [[build]]

--- a/ci/matrix_jobs.toml
+++ b/ci/matrix_jobs.toml
@@ -3,7 +3,7 @@ name = "Tooling"
 gradle_args = ["--project-dir", "build-logic", ":check"]
 
 [[build]]
-name = "Build release publisher"
+name = "Release publisher"
 gradle_args = [":publish:check", ":publish:distTar"]
 upload_name = "release-publisher"
 upload_path = "publish/build/distributions/*.tar"

--- a/ci/src/freecam_ci/build_matrix.py
+++ b/ci/src/freecam_ci/build_matrix.py
@@ -32,7 +32,7 @@ def build_version_matrix(
 
         matrix.append(
             MatrixJob(
-                name=f"Build {entry.project}",
+                name=f"MC {entry.project}",
                 gradle_args=gradle_args,
                 upload_name=f"freecam-{version}-{entry.project}",
                 upload_path=f"build/libs/{version}/*.jar",

--- a/ci/test/test_build_matrix.py
+++ b/ci/test/test_build_matrix.py
@@ -37,13 +37,13 @@ def test_build_version_matrix_basic():
     matrix = build_version_matrix(version, versions)
     assert len(matrix) == 2
     names = [job.name for job in matrix]
-    assert "Build 1.20" in names
-    assert "Build 1.21" in names
+    assert "MC 1.20" in names
+    assert "MC 1.21" in names
 
-    job_121 = next(job for job in matrix if job.name == "Build 1.21")
+    job_121 = next(job for job in matrix if job.name == "MC 1.21")
     assert job_121.gradle_args == [":neoforge:1.21:buildAndCollect"]
 
-    job_120 = next(job for job in matrix if job.name == "Build 1.20")
+    job_120 = next(job for job in matrix if job.name == "MC 1.20")
     assert job_120.gradle_args == [
         ":fabric:1.20:buildAndCollect",
         ":forge:1.20:buildAndCollect",


### PR DESCRIPTION
### New names render as:

<img width="1021" height="641" alt="image" src="https://github.com/user-attachments/assets/7f1b11a7-0fe9-4461-82fb-169f3a3122d6" />

### Concurrency

Builds are now grouped by **branch and event type**, using the exact ref (e.g. `refs/pull/393/merge` for PRs or `refs/heads/main` for pushes). This ensures a unique concurrency group for each workflow variant.

Concurrency behavior:

- Each group allows **at most one running workflow and one pending workflow**.
- Pending workflows **wait** for the running workflow to complete or be cancelled.
- A **new run cancels any pending workflow** in the group, which is then replaced.
- If `cancel-in-progress` is `true`, the running workflow is also cancelled to start the new workflow sooner.

#### Strategy

- **Push events**: Let started jobs finish to avoid wasting work, disrupting publishing, and to promote cache writes.
- **Pull request events**: Often arrive in quick succession; cancel outdated runs to start the latest run promptly.

Configured as:
```yaml
cancel-in-progress: ${{ github.event_name != 'push' }}
```

This balances efficiency with correctness, giving PRs fast feedback while preserving work for push events on long-lived branches.

#### Caveat

This setup assumes that **no fast-paced work occurs directly on non-fork branches** (e.g. `main`, `i18n/main`, `stonecutter`). If that assumption does not hold, alternative strategies may be needed:

- Attempt to cancel push workflows corresponding to the same commit as a PR (e.g. a `prepare` step, on push).
  - Such strategies would **only test the PR’s `merge` commit**, not the pushed `head` commit—subtly changing what is tested for pushes.
- Adjust `cancel-in-progress` to be branch-specific, e.g., only for `main`:
  ```yaml
  cancel-in-progress: ${{ github.event_name != 'push' && github.ref == 'refs/heads/main' }}
  ```
