### PR TITLE
fix(mixin): apply Iris mixins dynamically

### DIFF
--- a/common/src/main/java/net/xolt/freecam/FreecamMixinConfig.java
+++ b/common/src/main/java/net/xolt/freecam/FreecamMixinConfig.java
@@ -9,11 +9,19 @@ import java.util.Set;
 
 public class FreecamMixinConfig implements IMixinConfigPlugin {
 
+    private static final List<String> DYNAMIC_MIXINS = List.of(
+            "net.xolt.freecam.mixins.IrisHandRendererMixin",
+            "net.xolt.freecam.mixins.IrisShadowRendererMixin"
+    );
+
     @Override
     public void onLoad(String mixinPackage) {}
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (DYNAMIC_MIXINS.contains(mixinClassName)) {
+            return isClassLoaded(targetClassName);
+        }
         return true;
     }
 
@@ -35,4 +43,13 @@ public class FreecamMixinConfig implements IMixinConfigPlugin {
 
     @Override
     public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    private static boolean isClassLoaded(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
 }

--- a/common/src/main/java/net/xolt/freecam/FreecamMixinConfig.java
+++ b/common/src/main/java/net/xolt/freecam/FreecamMixinConfig.java
@@ -1,0 +1,38 @@
+package net.xolt.freecam;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class FreecamMixinConfig implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {}
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/common/src/main/resources/freecam-common.mixins.json
+++ b/common/src/main/resources/freecam-common.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "net.xolt.freecam.mixins",
+  "plugin": "net.xolt.freecam.FreecamMixinConfig",
   "compatibilityLevel": "${mixinCompatLevel}",
   "minVersion": "0.8",
   "client": [

--- a/fabric/src/main/resources/freecam-fabric.mixins.json
+++ b/fabric/src/main/resources/freecam-fabric.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "net.xolt.freecam.fabric.mixins",
+  "plugin": "net.xolt.freecam.FreecamMixinConfig",
   "compatibilityLevel": "${mixinCompatLevel}",
   "minVersion": "0.8",
   "client": [

--- a/forge/src/main/resources/freecam-forge.mixins.json
+++ b/forge/src/main/resources/freecam-forge.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "net.xolt.freecam.forge.mixins",
+  "plugin": "net.xolt.freecam.FreecamMixinConfig",
   "compatibilityLevel": "${mixinCompatLevel}",
   "minVersion": "0.8",
   "client": [

--- a/neoforge/src/main/resources/freecam-neoforge.mixins.json
+++ b/neoforge/src/main/resources/freecam-neoforge.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "net.xolt.freecam.forge.mixins",
+  "plugin": "net.xolt.freecam.FreecamMixinConfig",
   "compatibilityLevel": "${mixinCompatLevel}",
   "minVersion": "0.8",
   "client": [


### PR DESCRIPTION
- **chore: add a Mixin config plugin**
- **fix(mixin): apply Iris mixins dynamically**

Adds a mixin config plugin that checks whether Iris is loaded before applying our mixins.

This prevents "failed to apply" log spam when Iris is not loaded.

The mixin config plugin can also be used for setting up [MixinExtras](https://github.com/LlamaLad7/MixinExtras), _if_ we ever need to do so on older versions that didn't come with it out of the box.
