### PR TITLE
fix(neoforge): move setup to FMLClientSetupEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- Fixed a crash on NeoForge, caused by setup happening too early ([391](https://github.com/MinecraftFreecam/Freecam/issues/391), [397](https://github.com/MinecraftFreecam/Freecam/issues/397))
+
 ## [1.4.0-alpha.1] - 2026-03-31
 
 This version includes major underlying changes. Feedback and bug reports are greatly appreciated!

--- a/neoforge/src/main/java/net/xolt/freecam/forge/FreecamNeoforge.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/FreecamNeoforge.java
@@ -7,6 +7,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
@@ -25,7 +26,6 @@ import net.xolt.freecam.config.gui.ConfigScreenProvider;
 public class FreecamNeoforge {
 
     public FreecamNeoforge(ModContainer container) {
-        ModConfig.setup();
         // Register our config screen with Forge
         container.registerExtensionPoint(
                 IConfigScreenFactory.class,
@@ -33,6 +33,10 @@ public class FreecamNeoforge {
         );
     }
 
+    @SubscribeEvent
+    public static void clientSetup(FMLClientSetupEvent event) {
+        ModConfig.setup();
+    }
 
     @SubscribeEvent
     public static void registerKeymappings(RegisterKeyMappingsEvent event) {


### PR DESCRIPTION
Doing setup in `FreecamForge`'s constructor is too early, leading to an NPE when we dereference `Minecraft.getInstance()`.

In legacy Forge we already used the `FMLClientSetup` event. We moved our NeoForge setup to the constructor when they made `ModContainer` available there.

This justifies an `alpha.2`, as the NPE is a critical issue for NeoForge users.
