### PR TITLE
ci(changelog): integrate into build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,6 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       do_release: ${{ steps.check_release.outputs.do_release }}
-      unreleased: ${{ steps.check_release.outputs.unreleased }}
-      touches_changelog: ${{ steps.changed_files.outputs.changelog }}
       matrix: ${{ steps.matrix.outputs.matrix }}
 
     steps:
@@ -129,9 +127,24 @@ jobs:
       - name: Generate build matrix
         id: matrix
         env:
+          touches_changelog: ${{ steps.changed_files.outputs.changelog }}
+          unreleased: ${{ steps.check_release.outputs.unreleased }}
           version: ${{ steps.version.outputs.version }}
         run: |
-          uv run build-matrix --version "$version" --output matrix.json
+          args=(
+            --version "$version"
+            --output matrix.json
+          )
+
+          # If 'unreleased' is set, that means the version has been bumped.
+          # Otherwise, we build the in-progress [Unreleased] changelog section.
+          if [ -n "$unreleased" ]; then
+            args+=( --release-changelog )
+          elif [ -n "$touches_changelog" ]; then
+            args+=( --unreleased-changelog )
+          fi
+
+          uv run build-matrix "${args[@]}"
           echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
 
   build:
@@ -214,70 +227,6 @@ jobs:
             echo "_Expires on **$(date --utc --date=+"$upload_days"days +%F)** (UTC)._"
             echo
           ) >> "$GITHUB_STEP_SUMMARY"
-
-  changelog:
-    name: Changelog
-    needs: prepare
-    runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request && (
-        needs.prepare.outputs.unreleased ||
-        needs.prepare.outputs.touches_changelog
-      )
-    timeout-minutes: 20
-
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: temurin
-      - uses: gradle/actions/setup-gradle@v5
-
-      - name: Generate changelog
-        env:
-          # If 'unreleased' is set, that means the version has been bumped.
-          # Otherwise, we build the in-progress [Unreleased] changelog section.
-          version: ${{ needs.prepare.outputs.unreleased && needs.prepare.outputs.version || 'Unreleased' }}
-        run: |
-          args=( :getChangelog --output-file build/changelog.md )
-
-          if [ "$version" = "Unreleased" ]; then
-            args+=( --unreleased )
-          else
-            args+=( --project-version "${version#v}" )
-          fi
-
-          echo "::group::Gradle"
-          ./gradlew "${args[@]}"
-          echo "::endgroup::"
-
-          if [ -s build/changelog.md ]; then
-            echo "::group::Changelog"
-            cat build/changelog.md
-            echo "::endgroup::"
-            {
-              echo "# Changelog"
-              echo
-              cat build/changelog.md
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error file=CHANGELOG.md::$version changelog is empty"
-            exit 1
-          fi
-
-      - name: Upload changelog
-        id: upload
-        uses: actions/upload-artifact@v7
-        with:
-          path: build/changelog.md
-          archive: false
-          retention-days: 30
-          if-no-files-found: error
 
   publish:
     if: needs.prepare.outputs.do_release || github.event.pull_request

--- a/ci/src/freecam_ci/build_matrix.py
+++ b/ci/src/freecam_ci/build_matrix.py
@@ -44,6 +44,36 @@ def build_version_matrix(
     return matrix
 
 
+def build_changelog_job(
+    release: bool = False,
+    version: str | None = None,
+    file: str = "changelog.md",
+) -> MatrixJob:
+    """
+    Construct a matrix job for building the changelog.
+
+    Note: `version` is only used when `release=True`.
+    """
+
+    if release and version is None:
+        raise ValueError("build_changelog_job: version is required when release=True")
+
+    output = f"build/{file}"
+
+    return MatrixJob(
+        name="Changelog",
+        gradle_args=[
+            ":getChangelog",
+            f"--project-version={version}" if release else "--unreleased",
+            f"--output-file={output}",
+        ],
+        upload=MatrixUpload(
+            path=output,
+            archive=False,
+        ),
+    )
+
+
 def load_versions(
     key: str = "versions",
     versions_file: Path = STONECUTTER_FILE,
@@ -82,6 +112,21 @@ def parse_args() -> argparse.Namespace:
         default=MATRIX_JOBS_FILE,
         help="path to static matrix jobs file (pass 'none' to disable)",
     )
+    changelog = parser.add_mutually_exclusive_group()
+    changelog.add_argument(
+        "--release-changelog",
+        dest="changelog",
+        action="store_const",
+        const="release",
+        help="build the release changelog for the given version",
+    )
+    changelog.add_argument(
+        "--unreleased-changelog",
+        dest="changelog",
+        action="store_const",
+        const="unreleased",
+        help="build the unreleased changelog section",
+    )
     parser.add_argument(
         "--version", type=str, help="project version (default read from metadata.toml)"
     )
@@ -102,6 +147,15 @@ def main() -> None:
         versions=load_versions(versions_file=args.versions_file),
     )
 
+    changelog_jobs = []
+    if args.changelog:
+        changelog_jobs.append(
+            build_changelog_job(
+                release=args.changelog == "release",
+                version=args.version,
+            )
+        )
+
     static_jobs: list[MatrixJob] = []
     if args.jobs_file:
         static_jobs = load_matrix_jobs(matrix_jobs_file=args.jobs_file)
@@ -109,7 +163,14 @@ def main() -> None:
     # Convert all jobs to dicts for JSON output
     matrix = [
         job.to_dict()
-        for job in sorted(version_jobs + static_jobs, key=lambda job: job.name)
+        for job in sorted(
+            [
+                *changelog_jobs,
+                *static_jobs,
+                *version_jobs,
+            ],
+            key=lambda job: job.name,
+        )
     ]
 
     # Print compact to output


### PR DESCRIPTION
Drop the dedicated `Build / Changelog` job, replacing it with a `Build / Changelog` run by the matrix job.
