### PR TITLE
build: extract changelog plugin to its own build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,1 +1,0 @@
-// This file represents the per-version `rootProject` (e.g. :1.21.11)

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,38 @@
+# Changelog build
+
+Responsible for building and managing the [project changelog](../CHANGELOG.md).
+
+## Usage
+
+For convenience, you can call changelog tasks from the [root project](..) using `:changelog:<task>` path notation.
+However, if you `cd` into this directory or specify it via `--project-dir`, then tasks may execute significantly faster.
+
+```shell
+# Slow
+./gradlew :changelog:patchChangelog
+```
+
+```shell
+# Fast
+./gradlew --project-dir changelog patchChangelog
+```
+
+```shell
+# Also fast
+cd changelog
+../gradlew patchChangelog
+```
+
+### Common tasks
+
+- `getChangelog` to get the current version's changelog section.
+- `getChangelog --unreleased` to get the in-progress 'unreleased' section.
+- `getChangelog --project-version 1.3.6` to get `v1.3.6`'s changelog section.
+- `getReleaseNotes` to get the current version's changelog, formatted as release notes (stripped of headers and links).
+- `patchChangelog` updates the unreleased section to the given version. Typically run after bumping the version in `metadata.toml`.
+
+## Upstream
+
+We use the JetBrains [gradle-changelog-plugin]. Refer to the upstream README for more detailed documentation.
+
+[gradle-changelog-plugin]: https://github.com/JetBrains/gradle-changelog-plugin

--- a/changelog/build.gradle.kts
+++ b/changelog/build.gradle.kts
@@ -1,0 +1,82 @@
+import dev.eav.tomlkt.*
+import org.jetbrains.changelog.tasks.GetChangelogTask
+
+plugins {
+    alias(libs.plugins.jetbrains.changelog)
+}
+
+buildscript {
+    dependencies.classpath(libs.kotlin.serialization.toml)
+}
+
+/** The actual changelog file lives outside this build, in the repo root. */
+val src = rootDir.resolveSibling("CHANGELOG.md")
+
+/**
+ * To minimize dependencies, we don't have `ModMetadata` or `freecam.metadata` here.
+ * For now, just load it manually as a raw [TomlTable].
+ */
+val meta by lazy {
+    logger.lifecycle("[changelog] Loading mod metadata")
+    rootDir.resolveSibling("metadata.toml").bufferedReader().use { reader ->
+        Toml.decodeFromReader<TomlTable>(TomlNativeReader(reader))
+    }.getTable("mod")
+}
+
+changelog {
+    path = src.canonicalPath
+
+    // Use metadata.toml's mod version
+    version = provider { meta.getString("version") }
+
+    // Use metadata.toml's GitHub URL to form tag & diff links
+    repositoryUrl = provider { meta.getString("source") }
+
+    // Title & intro are printed right at the start of the changelog.
+    // The values here will replace whatever exists in the file when patching.
+    title = "Changelog"
+    introduction = """
+    All notable changes to this project will be documented in this file.
+    
+    This file is formatted as per [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
+    and Freecam's versioning is based on [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+    """.trimIndent()
+
+    // Group sub-headings added to the "unreleased" section when patching the changelog.
+    // Other sub-headings can still be added manually, if required.
+    groups = listOf(
+        "Added",
+        "Changed",
+        "Removed",
+        "Fixed",
+    )
+
+    // Regex used to find versions in headings.
+    // The default regex only supports semantic versions, this one is more lenient.
+    headerParserRegex = "(\\d+(?:\\.\\d+)+(?:-[-a-z]+(?:\\.\\d+)?)?)".toRegex()
+}
+
+val getReleaseNotes by tasks.registering(GetChangelogTask::class) {
+    group = "changelog"
+    description = "Builds the current release notes"
+    changelog = project.changelog.instance
+
+    noHeader = true
+    noLinks = true
+    noEmptySections = true
+    noSummary = false
+    unreleased = false
+
+    outputFile = project.changelog.version.flatMap { version ->
+        project.layout.buildDirectory.file("build/$version/changelog.md")
+    }
+}
+
+val releaseNotes by configurations.registering {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+
+    outgoing.artifacts(getReleaseNotes.map { it.outputs.files }) {
+        builtBy(getReleaseNotes)
+    }
+}

--- a/changelog/settings.gradle.kts
+++ b/changelog/settings.gradle.kts
@@ -1,0 +1,13 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "changelog"

--- a/ci/src/freecam_ci/build_matrix.py
+++ b/ci/src/freecam_ci/build_matrix.py
@@ -58,17 +58,16 @@ def build_changelog_job(
     if release and version is None:
         raise ValueError("build_changelog_job: version is required when release=True")
 
-    output = f"build/{file}"
-
     return MatrixJob(
         name="Changelog",
         gradle_args=[
+            "--project-dir=changelog",
             ":getChangelog",
             f"--project-version={version}" if release else "--unreleased",
-            f"--output-file={output}",
+            f"--output-file=build/{file}",
         ],
         upload=MatrixUpload(
-            path=output,
+            path=f"changelog/build/{file}",
             archive=False,
         ),
     )

--- a/metadata.toml
+++ b/metadata.toml
@@ -3,7 +3,7 @@ name = "Freecam"
 id = "freecam"
 group = "net.xolt.freecam"
 # Version can specify a semver pre-release, e.g. -alpha.1
-# Remember to run `:patchChangelog` when updating
+# Remember to run :changelog:patchChangelog when updating
 version = "1.4.0-alpha.2"
 authors = ["hashalite", "Matt Sturgeon"]
 description = "A highly customizable freecam mod."

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,4 +46,6 @@ include(
     "publish:platforms",
 )
 
+includeBuild("changelog")
+
 rootProject.name = "freecam"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,6 +1,3 @@
-import org.jetbrains.changelog.Changelog
-import org.jetbrains.changelog.tasks.BaseChangelogTask
-
 // This file represents the version-less `rootProject` (:)
 // Version-agnostic tasks should go here, as well as configuration for stonecutter itself
 
@@ -8,7 +5,6 @@ plugins {
     id("freecam.api")
     id("freecam.release-metadata")
     id("dev.kikugie.stonecutter")
-    alias(libs.plugins.jetbrains.changelog)
 }
 
 stonecutter active "26.1"
@@ -84,54 +80,26 @@ stonecutter parameters {
     }
 }
 
+val releaseNotes by configurations.registering {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    releaseNotes(project(":changelog", configuration = "releaseNotes"))
+}
+
+tasks.generateReleaseMetadata {
+    changelog = releaseNotes.map { it.singleFile.readText() }
+
+    // FIXME: the :changelog outgoing artifact should encode its dependencies,
+    //  this project shouldn't need to know about the underlying task.
+    //  See https://github.com/gradle/gradle/issues/24131
+    dependsOn(gradle.includedBuild("changelog").task(":getReleaseNotes"))
+}
+
 tasks.named<Wrapper>("wrapper") {
     // Use "all" so we get sources and javadoc too
     distributionType = Wrapper.DistributionType.ALL
     gradleVersion = "9.2.1"
-}
-
-// Move the changelog tasks to the "version" group
-tasks.withType<BaseChangelogTask>().configureEach {
-    group = "version"
-}
-
-changelog {
-    // Use the mod_version in gradle.properties as the release version/tag.
-    // Build tag/diff links using the github repo URL.
-    version = meta.version
-    repositoryUrl = meta.sourceUrl.toString()
-
-    // Title & intro are printed right at the start of the changelog.
-    // The values here will replace whatever exists in the file when patching.
-    title = "Changelog"
-    introduction = """
-    All notable changes to this project will be documented in this file.
-    
-    This file is formatted as per [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
-    and Freecam's versioning is based on [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-    """.trimIndent()
-
-    // Group sub-headings added to the "unreleased" section when patching the changelog.
-    // Other sub-headings can still be added manually, if required.
-    groups = listOf("Added",
-        "Changed",
-        "Removed",
-        "Fixed")
-
-    // Regex used to find versions in headings.
-    // The default regex only supports semantic versions, this one is more lenient.
-    headerParserRegex = Regex("(\\d+(?:\\.\\d+)+(?:-[-a-z]+(?:\\.\\d+)?)?)")
-}
-
-tasks.generateReleaseMetadata {
-    changelog = provider {
-        val entry = project.changelog.getOrNull(meta.version) ?: project.changelog.getUnreleased()
-        project.changelog.renderItem(
-            entry.withHeader(false)
-                .withLinks(false)
-                .withEmptySections(false)
-                .withSummary(true),
-            outputType = Changelog.OutputType.MARKDOWN
-        )
-    }
 }


### PR DESCRIPTION
- **build: remove unused buildscript**
- **build: extract changelog plugin to its own build**
    This makes it possible to execute `:getChangelog` (etc) without configuring the entire Freecam project, which is significantly faster especially in CI.