### PR TITLE
fix(i18n): drop extra `.toml` extension in Crowdin config

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -4,4 +4,4 @@ preserve_hierarchy: false
 
 files:
   - source: '/i18n/src/main/en_US/*.toml'
-    translation: '/i18n/src/main/%locale_with_underscore%/%original_file_name%.toml'
+    translation: '/i18n/src/main/%locale_with_underscore%/%original_file_name%'


### PR DESCRIPTION
`%original_file_name%.toml` is `foo.toml.toml`, we just want `%original_file_name%` on its own.

Oops
