### PR TITLE
ci(i18n): drop skip_untranslated_files

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -195,7 +195,6 @@ jobs:
           upload_translations: false
           download_translations: true
           skip_untranslated_strings: true
-          skip_untranslated_files: true
           create_pull_request: true
           pull_request_title: |
             i18n: new translations from Crowdin


### PR DESCRIPTION
> You cannot skip strings and files at the same time. Please use one of these parameters instead.

Looking at the docs, skip_untranslated_files will only download files that are _fully_ translated, which isn't what we want.
