### PR TITLE
ci(comment): `workflow_run` → `pull_request_target`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,132 +20,13 @@ defaults:
 jobs:
   prepare:
     name: Setup
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
+    uses: ./.github/workflows/prepare.yaml
     permissions:
-      # 'read' avoids accidental access to draft releases.
       contents: read
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      do_release: ${{ steps.check_release.outputs.do_release }}
-      matrix: ${{ steps.matrix.outputs.matrix }}
-
-    steps:
-      - name: Checkout required files
-        uses: actions/checkout@v6
-        with:
-          sparse-checkout: |
-            ci
-            metadata.toml
-            stonecutter.settings.toml
-            pyproject.toml
-            uv.lock
-          sparse-checkout-cone-mode: false
-
-      - name: Save PR number
-        if: github.event.pull_request
-        env:
-          pr: ${{ github.event.pull_request.number }}
-        run: |
-          echo "$pr" > pr_number
-
-      - name: Upload PR number
-        if: github.event.pull_request
-        uses: actions/upload-artifact@v7
-        with:
-          path: pr_number
-          archive: false
-          retention-days: 30
-          if-no-files-found: error
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version-file: pyproject.toml
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install CI dependencies
-        run: uv sync --locked --no-group dev
-
-      - name: Get changed files
-        id: changed_files
-        # Currently only used on PR events
-        if: github.event.pull_request
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const result = await github.graphql(
-              `query($owner: String!, $repo: String!, $pr: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $pr) {
-                    files(first: 100) {
-                      nodes { path }
-                    }
-                  }
-                }
-              }`,
-              {
-                ...context.repo,
-                pr: context.payload.pull_request.number,
-              }
-            )
-            const files = result.repository.pullRequest.files.nodes
-            if (files.some(f => f.path === "CHANGELOG.md")) {
-              core.notice("This PR touches the changelog")
-              core.setOutput("changelog", "true")
-            } else if (files.length === 100) {
-              core.warning("PR has ≥100 files — file detection may be incomplete")
-            }
-
-      - name: Read project version
-        id: version
-        run: |
-          version=$(yq .mod.version metadata.toml)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Check whether this version is released
-        id: check_release
-        if: github.event.pull_request || github.ref == 'refs/heads/main'
-        uses: actions/github-script@v8
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        with:
-          script: |
-            const tag = `v${process.env.VERSION}`
-            const push = context.eventName === "push"
-            try {
-              const { data } = await github.rest.repos.getReleaseByTag({ ...context.repo, tag })
-              core.notice(`${tag} already published (${data.published_at})`)
-            } catch (err) {
-              if (err.status !== 404) throw err
-              core.notice(`${tag} not published — creating release`)
-              core.setOutput("unreleased", "true")
-              if (push) core.setOutput("do_release", "true")
-            }
-
-      - name: Generate build matrix
-        id: matrix
-        env:
-          touches_changelog: ${{ steps.changed_files.outputs.changelog }}
-          unreleased: ${{ steps.check_release.outputs.unreleased }}
-          version: ${{ steps.version.outputs.version }}
-        run: |
-          args=(
-            --version "$version"
-            --output matrix.json
-          )
-
-          # If 'unreleased' is set, that means the version has been bumped.
-          # Otherwise, we build the in-progress [Unreleased] changelog section.
-          if [ -n "$unreleased" ]; then
-            args+=( --release-changelog )
-          elif [ -n "$touches_changelog" ]; then
-            args+=( --unreleased-changelog )
-          fi
-
-          uv run build-matrix "${args[@]}"
-          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+    with:
+      changelog: ${{ github.event_name != 'push' }}
+      release: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
+      matrix: true
 
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,22 +1,18 @@
 name: Comment
 
 on:
-  workflow_run:
-    workflows:
-      - Build
+  pull_request_target:
+    branches: [main]
     types:
-      - completed
+      - opened
+      - reopened
+      - synchronize
 
 # Group workflow runs by event + PR.
 # New runs cancel any pending run.
 # In-progress runs are allowed to complete.
 concurrency:
-  group: >
-    pr-comment-${{ github.event.workflow_run.event }}-${{
-      github.event.workflow_run.pull_requests &&
-      github.event.workflow_run.pull_requests[0] &&
-      github.event.workflow_run.pull_requests[0].number
-    }}
+  group: pr-comment-${{ github.event.number }}
 
 permissions: {}
 
@@ -25,13 +21,84 @@ defaults:
     shell: bash
 
 jobs:
+  prepare:
+    name: Setup
+    uses: ./.github/workflows/prepare.yaml
+    permissions:
+      contents: read
+    with:
+      changelog: true
+
+
+  find_build:
+    name: Find build
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+
+    permissions:
+      actions: read # For listing workflow runs
+
+    outputs:
+      id: ${{ steps.find.outputs.id }}
+
+    steps:
+      - name: Find workflow run
+        id: find
+        timeout-minutes: 6 # deadline + 1
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const head_sha = context.payload.pull_request.head.sha
+            const deadline = Date.now() + 5 * 60_000 // 5 minutes
+
+            const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+            const backoff = (() => {
+              let delay = 5_000
+              return async () => {
+                await sleep(delay)
+                delay = Math.min(delay * 1.5, 15_000)
+              }
+            })()
+
+            core.info("Polling for 'build.yml' workflow run")
+            const workflow = await (async () => {
+              while (Date.now() < deadline) {
+                const iterator = github.paginate.iterator(
+                  github.rest.actions.listWorkflowRunsForRepo,
+                  {
+                    owner,
+                    repo,
+                    event: "pull_request",
+                    head_sha,
+                    exclude_pull_requests: true,
+                    per_page: 100, // Minimize requests
+                  }
+                )
+
+                for await (const page of iterator) {
+                  const match = page.data
+                    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+                    .find(run => run.path === ".github/workflows/build.yaml")
+                  if (match) return match
+                }
+
+                await backoff()
+              }
+            })()
+
+            if (!workflow) {
+              core.setFailed("Timed out looking for build workflow run")
+              return
+            }
+
+            core.setOutput("id", workflow.id)
+
   sync:
     name: Sync
     runs-on: ubuntu-slim
-    if: >
-      github.event.workflow_run.conclusion != 'cancelled' &&
-      github.event.workflow_run.event == 'pull_request'
-    timeout-minutes: 10
+    needs: [prepare, find_build]
+    timeout-minutes: 15
 
     permissions:
       actions: read # For downloading artifacts
@@ -39,14 +106,65 @@ jobs:
       pull-requests: write # For posting comments
 
     steps:
-      - name: Download artifacts
+      - name: Wait for changelog
+        id: find
+        if: needs.prepare.outputs.changelog_comment
+        timeout-minutes: 11 # deadline + 1
+        uses: actions/github-script@v8
+        env:
+          RUN_ID: ${{ needs.find_build.outputs.id }}
+        with:
+          script: |
+            const { owner, repo } = context.repo
+            const run_id = process.env.RUN_ID
+            const deadline = Date.now() + 10 * 60_000 // 10 minutes
+
+            const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+            const backoff = (() => {
+              let delay = 3_000
+
+              return async () => {
+                await sleep(delay)
+                delay = Math.min(delay * 1.25, 20_000)
+              }
+            })()
+
+            // Due to Java & Gradle setup, the changelog usually takes ~1m to build.
+            // Wait 45s before polling, to reduce wasteful API calls.
+            core.info("Waiting 45s before starting...")
+            await sleep(45_000)
+
+            core.info("Polling for changelog.md")
+            const changelog = await (async () => {
+              while (Date.now() < deadline) {
+                const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                  owner,
+                  repo,
+                  run_id,
+                })
+
+                const match = artifacts.data.artifacts.find(a => a.name === "changelog.md")
+                if (match) return match
+
+                await backoff()
+              }
+            })()
+
+            if (!changelog) {
+              core.setFailed("Timed out waiting for changelog artifact")
+              return
+            }
+
+            core.setOutput("id", changelog.id)
+
+      - name: Download artifact
         id: download
+        if: steps.find.outputs.id
         uses: actions/download-artifact@v8
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ needs.find_build.outputs.id }}
+          artifact-ids: ${{ steps.find.outputs.id }}
           github-token: ${{ github.token }}
-          merge-multiple: true
-          pattern: '{pr_number,changelog.md}'
 
       - name: Sync PR comment
         uses: actions/github-script@v8
@@ -55,23 +173,9 @@ jobs:
             const { readFileSync } = require("fs")
 
             const { owner, repo } = context.repo
-            const runId = context.payload.workflow_run.id
-            const runConclusion = context.payload.workflow_run.conclusion
+            const issue_number = context.payload.number
             const botId = 41898282 // github-actions[bot]
             const marker = "<!-- changelog-preview -->"
-
-            // Read the PR number
-            const pr = (function() {
-              try {
-                 const str = readFileSync("pr_number", "utf8").trim()
-                 const result = parseInt(str)
-                 if (result > 0) return result
-                 throw new Error(`Invalid PR number '${str}'`)
-              } catch (err) {
-                core.error(`Error getting 'pr_number' artifact for workflow run ${runId}`)
-                throw err
-              }
-            })()
 
             // Read the optional changelog body
             const body = (function() {
@@ -88,7 +192,7 @@ jobs:
             const existing = await (async function() {
               const iterator = github.paginate.iterator(
                 github.rest.issues.listComments,
-                { owner, repo, issue_number: pr }
+                { owner, repo, issue_number }
               )
 
               for await (const page of iterator) {
@@ -103,11 +207,6 @@ jobs:
             })()
 
             if (!body) {
-              if (runConclusion !== "success") {
-                core.notice("Workflow run unsuccessful and no changelog; leaving comment untouched")
-                return
-              }
-
               if (!existing) {
                 core.notice("No changelog and no existing comment")
                 return
@@ -153,6 +252,6 @@ jobs:
             await github.rest.issues.createComment({
               owner,
               repo,
-              issue_number: pr,
+              issue_number,
               body,
             })

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -22,6 +22,9 @@ on:
       do_release:
         description: Whether to publish a GitHub Release
         value: ${{ jobs.prepare.outputs.do_release }}
+      changelog_comment:
+        description: Whether to post a PR comment displaying the current changelog
+        value: ${{ jobs.prepare.outputs.changelog_comment }}
       matrix:
         description: The build matrix
         value: ${{ jobs.prepare.outputs.matrix }}
@@ -52,6 +55,11 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       do_release: ${{ steps.check_release.outputs.do_release }}
+      changelog_comment: >-
+        ${{
+          steps.changed_files.outputs.changelog ||
+          steps.check_release.outputs.unreleased
+        }}
       matrix: ${{ steps.matrix.outputs.matrix }}
 
     steps:
@@ -61,27 +69,24 @@ jobs:
         with:
           sparse-checkout: |
             ci
-            metadata.toml
-            stonecutter.settings.toml
             pyproject.toml
             uv.lock
           sparse-checkout-cone-mode: false
 
-      - name: Save PR number
-        if: github.event.pull_request
-        env:
-          pr: ${{ github.event.pull_request.number }}
-        run: |
-          echo "$pr" > pr_number
-
-      - name: Upload PR number
-        if: github.event.pull_request
-        uses: actions/upload-artifact@v7
+      # Checkout metadata separately, as we want the untrusted files on pr_target runs
+      - name: Checkout PR metadata
+        uses: actions/checkout@v6
         with:
-          path: pr_number
-          archive: false
-          retention-days: 30
-          if-no-files-found: error
+          ref: >
+            ${{
+              github.event.pull_request.merge_commit_sha ||
+              github.event.pull_request.head.sha ||
+              github.sha
+            }}
+          sparse-checkout: |
+            metadata.toml
+            stonecutter.settings.toml
+          sparse-checkout-cone-mode: false
 
       - uses: actions/setup-python@v6
         if: contains(env.scopes, 'python')

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -1,0 +1,176 @@
+name: Setup
+
+on:
+  workflow_call:
+    inputs:
+      changelog:
+        description: Check whether a changelog comment should be posted
+        type: boolean
+        default: false
+      release:
+        description: Check whether a release should be made
+        type: boolean
+        default: false
+      matrix:
+        description: Build a job matrix
+        type: boolean
+        default: false
+    outputs:
+      version:
+        description: The current project version
+        value: ${{ jobs.prepare.outputs.version }}
+      do_release:
+        description: Whether to publish a GitHub Release
+        value: ${{ jobs.prepare.outputs.do_release }}
+      matrix:
+        description: The build matrix
+        value: ${{ jobs.prepare.outputs.matrix }}
+    secrets: {}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  # Scopes that can be queried using `contains(env.scopes, 'scope')`
+  scopes: >
+    ${{ inputs.matrix && 'python ci' || '' }}
+    ${{ inputs.changelog && 'files' || '' }}
+
+jobs:
+  prepare:
+    # If the calling job is named 'Setup', this will render as 'Setup / CI'
+    # E.g. 'Build / Setup / CI (pull_request)'
+    name: CI
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      # 'read' avoids accidental access to draft releases.
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      do_release: ${{ steps.check_release.outputs.do_release }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - name: Checkout required files
+        if: contains(env.scopes, 'ci') || contains(env.scopes, 'python')
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            ci
+            metadata.toml
+            stonecutter.settings.toml
+            pyproject.toml
+            uv.lock
+          sparse-checkout-cone-mode: false
+
+      - name: Save PR number
+        if: github.event.pull_request
+        env:
+          pr: ${{ github.event.pull_request.number }}
+        run: |
+          echo "$pr" > pr_number
+
+      - name: Upload PR number
+        if: github.event.pull_request
+        uses: actions/upload-artifact@v7
+        with:
+          path: pr_number
+          archive: false
+          retention-days: 30
+          if-no-files-found: error
+
+      - uses: actions/setup-python@v6
+        if: contains(env.scopes, 'python')
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install uv
+        if: contains(env.scopes, 'python')
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install CI dependencies
+        if: contains(env.scopes, 'python')
+        run: uv sync --locked --no-group dev
+
+      - name: Get changed files
+        id: changed_files
+        if: contains(env.scopes, 'files')
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const result = await github.graphql(
+              `query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    files(first: 100) {
+                      nodes { path }
+                    }
+                  }
+                }
+              }`,
+              {
+                ...context.repo,
+                pr: context.payload.pull_request.number,
+              }
+            )
+            const files = result.repository.pullRequest.files.nodes
+            if (files.some(f => f.path === "CHANGELOG.md")) {
+              core.notice("This PR touches the changelog")
+              core.setOutput("changelog", "true")
+            } else if (files.length === 100) {
+              core.warning("PR has ≥100 files — file detection may be incomplete")
+            }
+
+      - name: Read project version
+        id: version
+        run: |
+          version=$(yq .mod.version metadata.toml)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version is released
+        id: check_release
+        if: inputs.release || inputs.changelog
+        uses: actions/github-script@v8
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        with:
+          script: |
+            const tag = `v${process.env.VERSION}`
+            const push = context.eventName === "push"
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({ ...context.repo, tag })
+              core.notice(`${tag} already published (${data.published_at})`)
+            } catch (err) {
+              if (err.status !== 404) throw err
+              core.notice(`${tag} not published — creating release`)
+              core.setOutput("unreleased", "true")
+              if (push) core.setOutput("do_release", "true")
+            }
+
+      - name: Generate build matrix
+        id: matrix
+        if: inputs.matrix
+        env:
+          touches_changelog: ${{ steps.changed_files.outputs.changelog }}
+          unreleased: ${{ steps.check_release.outputs.unreleased }}
+          version: ${{ steps.version.outputs.version }}
+        run: |
+          args=(
+            --version "$version"
+            --output matrix.json
+          )
+
+          # If 'unreleased' is set, that means the version has been bumped.
+          # Otherwise, we build the in-progress [Unreleased] changelog section.
+          if [ -n "$unreleased" ]; then
+            args+=( --release-changelog )
+          elif [ -n "$touches_changelog" ]; then
+            args+=( --unreleased-changelog )
+          fi
+
+          uv run build-matrix "${args[@]}"
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Concept

Instead of waiting for `build.yaml` to fully complete before managing changelog comments, we now start a privileged run in parallel with the build and poll for the required artifact.

## Benefits

Using `pull_request_target` has several advantages:

1. We no longer trigger on `push` events (previously the workflow ran but skipped the job on `push`).
2. Full PR context is available without needing a `pr_number` artifact.
3. The workflow's jobs show up in the PR's status checks.
4. Starting immediately and polling is much more responsive than waiting for unrelated jobs to finish.

## Refactoring

To support this workflow, the `prepare` job has been extracted into a reusable workflow, invoked via `workflow_call` with inputs.

