### PR TITLE
Release `1.4.0-alpha.3`; fix Iris compatibility; related cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
-- The mod description is now translatable, but not yet translated ([172](https://github.com/MinecraftFreecam/Freecam/issues/172), [390](https://github.com/MinecraftFreecam/Freecam/pull/390))
-
 ### Changed
 
 ### Removed
+
+### Fixed
+
+## [1.4.0-alpha.3] - 2026-04-10
+
+This version includes major underlying changes. Feedback and bug reports are greatly appreciated!
+**[Bug tracker](https://github.com/MinecraftFreecam/Freecam/issues).**
+
+### Added
+
+- The mod description is now translatable, but not yet translated ([172](https://github.com/MinecraftFreecam/Freecam/issues/172), [390](https://github.com/MinecraftFreecam/Freecam/pull/390))
 
 ### Fixed
 
@@ -645,9 +654,10 @@ This version includes major underlying changes. Feedback and bug reports are gre
 - Minecraft 1.18 support.
 - Minecraft 1.17 support.
 
-[Unreleased]: https://github.com/MinecraftFreecam/Freecam/compare/v1.4.0-alpha.2...HEAD
-[1.4.0-alpha.1]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.6...v1.4.0-alpha.1
+[Unreleased]: https://github.com/MinecraftFreecam/Freecam/compare/v1.4.0-alpha.3...HEAD
+[1.4.0-alpha.3]: https://github.com/MinecraftFreecam/Freecam/compare/v1.4.0-alpha.2...v1.4.0-alpha.3
 [1.4.0-alpha.2]: https://github.com/MinecraftFreecam/Freecam/compare/v1.4.0-alpha.1...v1.4.0-alpha.2
+[1.4.0-alpha.1]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.6...v1.4.0-alpha.1
 [1.3.6]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/MinecraftFreecam/Freecam/compare/v1.3.3...v1.3.4
@@ -699,7 +709,7 @@ This version includes major underlying changes. Feedback and bug reports are gre
 [0.2.5]: https://github.com/MinecraftFreecam/Freecam/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/MinecraftFreecam/Freecam/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/MinecraftFreecam/Freecam/compare/v0.2.2...v0.2.3
-[0.2.2]: https://github.com/MinecraftFreecam/Freecam/releases/tag/v0.2.2
-[0.3]: https://github.com/MinecraftFreecam/Freecam/compare/v0.2.5...v0.3
-[0.4.4.1]: https://github.com/MinecraftFreecam/Freecam/compare/v0.4.4...v0.4.4.1
+[0.2.2]: https://github.com/MinecraftFreecam/Freecam/commits/v0.2.2
 [1.2.1.1]: https://github.com/MinecraftFreecam/Freecam/compare/v1.2.1...v1.2.1.1
+[0.4.4.1]: https://github.com/MinecraftFreecam/Freecam/compare/v0.4.4...v0.4.4.1
+[0.3]: https://github.com/MinecraftFreecam/Freecam/compare/v0.2.5...v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- Iris rendering the player shadow when "Show Player" is enabled ([425](https://github.com/MinecraftFreecam/Freecam/issues/425), [426](https://github.com/MinecraftFreecam/Freecam/pull/426))
+
 ## [1.4.0-alpha.2] - 2026-04-04
 
 This version includes major underlying changes. Feedback and bug reports are greatly appreciated!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 ### Fixed
 
 - Iris rendering the player shadow when "Show Player" is enabled ([425](https://github.com/MinecraftFreecam/Freecam/issues/425), [426](https://github.com/MinecraftFreecam/Freecam/pull/426))
+- A NeoForge crash when Iris is installed, caused by loading Iris classes too early ([424](https://github.com/MinecraftFreecam/Freecam/issues/424), [426](https://github.com/MinecraftFreecam/Freecam/pull/426))
 
 ## [1.4.0-alpha.2] - 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
-- The mod description is now translatable, but not yet translated ([172](https://github.com/MinecraftFreecam/Freecam/pull/172), [390](https://github.com/MinecraftFreecam/Freecam/pull/390))
+- The mod description is now translatable, but not yet translated ([172](https://github.com/MinecraftFreecam/Freecam/issues/172), [390](https://github.com/MinecraftFreecam/Freecam/pull/390))
 
 ### Changed
 
@@ -27,7 +27,7 @@ This version includes major underlying changes. Feedback and bug reports are gre
 
 ### Fixed
 
-- Fixed a crash on NeoForge, caused by setup happening too early ([391](https://github.com/MinecraftFreecam/Freecam/issues/391), [397](https://github.com/MinecraftFreecam/Freecam/issues/397))
+- A NeoForge crash, caused by setup happening too early ([391](https://github.com/MinecraftFreecam/Freecam/issues/391), [397](https://github.com/MinecraftFreecam/Freecam/issues/397))
 
 ## [1.4.0-alpha.1] - 2026-03-31
 

--- a/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ProjectReleaseMetadataTask.kt
+++ b/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ProjectReleaseMetadataTask.kt
@@ -76,7 +76,7 @@ abstract class ProjectReleaseMetadataTask : DefaultTask() {
             loader = loader.get(),
             minecraft = mc,
             filename = artifactFileName.get(),
-            gameVersions = listOf(mc) + supportedMinecraftVersions.get(),
+            gameVersions = (supportedMinecraftVersions.get() + mc).sorted().distinct(),
             javaVersions = listOf(targetCompatibility.map(JavaVersion::toReleaseMetadataSlug).get()),
             relationships = relationships.get(),
         )

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -51,7 +51,7 @@ tasks.processResources {
         into("assets/${meta.id}/lang")
     }
 
-    filesMatching("freecam-common.mixins.json") {
+    filesMatching("freecam-common.mixins.json5") {
         expand(commonExpansions)
     }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 fletchingTable {
     j52j.register("main") {
+        prettyPrint = true
         extension("json", "**/*.json5")
     }
 }

--- a/common/src/main/java/net/xolt/freecam/FreecamMixinConfig.java
+++ b/common/src/main/java/net/xolt/freecam/FreecamMixinConfig.java
@@ -5,13 +5,14 @@ import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class FreecamMixinConfig implements IMixinConfigPlugin {
 
-    private static final List<String> DYNAMIC_MIXINS = List.of(
-            "net.xolt.freecam.mixins.IrisHandRendererMixin",
-            "net.xolt.freecam.mixins.IrisShadowRendererMixin"
+    private static final Map<String, String> MOD_MIXINS = Map.of(
+            "net.xolt.freecam.mixins.IrisHandRendererMixin", "iris",
+            "net.xolt.freecam.mixins.IrisShadowRendererMixin", "iris"
     );
 
     @Override
@@ -19,10 +20,8 @@ public class FreecamMixinConfig implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if (DYNAMIC_MIXINS.contains(mixinClassName)) {
-            return isClassLoaded(targetClassName);
-        }
-        return true;
+        String modId = MOD_MIXINS.get(mixinClassName);
+        return modId == null || ModPlatform.get().isModLoaded(modId);
     }
 
     @Override
@@ -43,13 +42,4 @@ public class FreecamMixinConfig implements IMixinConfigPlugin {
 
     @Override
     public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
-
-    private static boolean isClassLoaded(String className) {
-        try {
-            Class.forName(className);
-            return true;
-        } catch (ClassNotFoundException ignored) {
-            return false;
-        }
-    }
 }

--- a/common/src/main/java/net/xolt/freecam/ModPlatform.java
+++ b/common/src/main/java/net/xolt/freecam/ModPlatform.java
@@ -1,0 +1,46 @@
+package net.xolt.freecam;
+
+import net.xolt.freecam.util.MultiServiceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.ServiceLoader.Provider;
+import java.util.stream.Collectors;
+
+public interface ModPlatform {
+
+    boolean isModLoaded(String modId);
+
+    static ModPlatform get() {
+        return Holder.INSTANCE;
+    }
+
+    final class Holder {
+        private Holder() {}
+
+        private static final Logger LOGGER = LoggerFactory.getLogger("Freecam/ModPlatform");
+        private static final ModPlatform INSTANCE;
+
+        static {
+            Collection<Provider<ModPlatform>> providers = MultiServiceLoader.get(ModPlatform.class);
+
+            LOGGER.debug("Loaded: {}", providers.stream()
+                    .map(provider -> provider.type().getSimpleName())
+                    .collect(Collectors.joining(", "))
+            );
+
+            INSTANCE = providers.stream()
+                    .findFirst()
+                    .map(provider -> {
+                        LOGGER.debug("Using {}", provider.type().getSimpleName());
+                        return provider.get();
+                    })
+                    .orElseThrow(() -> {
+                        String msg = "No provider found";
+                        LOGGER.error(msg);
+                        return new IllegalStateException(msg);
+                    });
+        }
+    }
+}

--- a/common/src/main/java/net/xolt/freecam/mixins/EntityRenderDispatcherMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/EntityRenderDispatcherMixin.java
@@ -3,19 +3,25 @@ package net.xolt.freecam.mixins;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.world.entity.Entity;
+import net.xolt.freecam.Freecam;
+import net.xolt.freecam.config.ModConfig;
 import net.xolt.freecam.util.FreeCamera;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import static net.xolt.freecam.Freecam.MC;
+
 @Mixin(EntityRenderDispatcher.class)
 public class EntityRenderDispatcherMixin {
 
     // Prevents shadow being cast when Iris is enabled.
     @Inject(method = "shouldRender", at = @At("HEAD"), cancellable = true)
-    private void onShouldRender(Entity entity, Frustum frustum, double x, double y, double z, CallbackInfoReturnable<Boolean> cir) {
+    private void onShouldRender(Entity entity, Frustum culler, double camX, double camY, double camZ, CallbackInfoReturnable<Boolean> cir) {
         if (entity instanceof FreeCamera) {
+            cir.setReturnValue(false);
+        } else if (entity == MC.player && Freecam.isEnabled() && ModConfig.get().shouldHidePlayer()) {
             cir.setReturnValue(false);
         }
     }

--- a/common/src/main/java/net/xolt/freecam/mixins/IrisHandRendererMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/IrisHandRendererMixin.java
@@ -10,10 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
 @Mixin(
-        //? if >=1.20 {
+        //~ if >=1.20 'net.coderbot.iris.pipeline' -> 'net.irisshaders.iris.pathways'
         targets = "net.irisshaders.iris.pathways.HandRenderer",
-        //? } else
-        //targets = "net.coderbot.iris.pipeline.HandRenderer",
         remap = false
 )
 public class IrisHandRendererMixin {

--- a/common/src/main/java/net/xolt/freecam/mixins/IrisShadowRendererMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/IrisShadowRendererMixin.java
@@ -10,10 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Pseudo
 @Mixin(
-        //? if >=1.20 {
+        //~ if >=1.20 'net.coderbot.iris.pipeline' -> 'net.irisshaders.iris.shadows'
         targets = "net.irisshaders.iris.shadows.ShadowRenderer",
-        //? } else
-        //targets = "net.coderbot.iris.pipeline.ShadowRenderer",
         remap = false
 )
 public class IrisShadowRendererMixin {

--- a/common/src/main/java/net/xolt/freecam/mixins/IrisShadowRendererMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/IrisShadowRendererMixin.java
@@ -1,4 +1,14 @@
-package net.xolt.freecam.mixins;
+/**
+ * {@code renderPlayerEntity} is unused since 1.21.9.
+ * <p>
+ * Iris now renders players as normal entities, so we hook into {@link net.minecraft.client.renderer.entity.EntityRenderDispatcher#shouldRender}
+ * in {@link net.xolt.freecam.mixins.EntityRenderDispatcherMixin} instead.
+ *
+ * @see <a href="https://github.com/IrisShaders/Iris/commit/e61bb8124f71b6f5d555053bcb798ed2e882b18e"><code>e61bb812</code></a>
+ */
+
+//? if <1.21.9 {
+/*package net.xolt.freecam.mixins;
 
 import net.xolt.freecam.Freecam;
 import net.xolt.freecam.config.ModConfig;
@@ -24,3 +34,4 @@ public class IrisShadowRendererMixin {
         }
     }
 }
+*///? }

--- a/common/src/main/resources/freecam-common.mixins.json5
+++ b/common/src/main/resources/freecam-common.mixins.json5
@@ -15,7 +15,8 @@
     "GameRendererMixin",
     "GuiMixin",
     "IrisHandRendererMixin",
-    "IrisShadowRendererMixin",
+    //? if <1.21.6
+    //"IrisShadowRendererMixin",
     "ItemInHandRendererMixin",
     "LivingEntityMixin",
     "LocalPlayerMixin",

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -100,11 +100,7 @@ tasks {
             description = meta.description
             licenses = listOf(meta.license)
             meta.authors.forEach(::author)
-
-            icon {
-                size = 128
-                path = "icon.png"
-            }
+            icon("icon.png")
 
             client()
             entrypoint("client", "net.xolt.freecam.fabric.FreecamFabric")

--- a/fabric/src/main/java/net/xolt/freecam/fabric/FabricPlatform.java
+++ b/fabric/src/main/java/net/xolt/freecam/fabric/FabricPlatform.java
@@ -1,0 +1,12 @@
+package net.xolt.freecam.fabric;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.xolt.freecam.ModPlatform;
+
+public class FabricPlatform implements ModPlatform {
+
+    @Override
+    public boolean isModLoaded(String modId) {
+        return FabricLoader.getInstance().isModLoaded(modId);
+    }
+}

--- a/fabric/src/main/resources/META-INF/services/net.xolt.freecam.ModPlatform
+++ b/fabric/src/main/resources/META-INF/services/net.xolt.freecam.ModPlatform
@@ -1,0 +1,1 @@
+net.xolt.freecam.fabric.FabricPlatform

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -21,6 +21,7 @@ stonecutter replacements {
 
 fletchingTable {
     j52j.register("main") {
+        prettyPrint = true
         extension("json", "**/*.json5")
     }
 

--- a/forge/src/main/java/net/xolt/freecam/forge/ForgePlatform.java
+++ b/forge/src/main/java/net/xolt/freecam/forge/ForgePlatform.java
@@ -1,0 +1,13 @@
+package net.xolt.freecam.forge;
+
+import net.minecraftforge.fml.loading.LoadingModList;
+import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
+import net.xolt.freecam.ModPlatform;
+
+public class ForgePlatform implements ModPlatform {
+
+    @Override
+    public boolean isModLoaded(String modId) {
+        return LoadingModList.get().getMods().stream().map(ModInfo::getModId).anyMatch(modId::equals);
+    }
+}

--- a/forge/src/main/resources/META-INF/services/net.xolt.freecam.ModPlatform
+++ b/forge/src/main/resources/META-INF/services/net.xolt.freecam.ModPlatform
@@ -1,0 +1,1 @@
+net.xolt.freecam.forge.ForgePlatform

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 kotlin = "2.3.0"
 stonecutter = "0.9.1-beta.4"
-fabric-loom = "1.15-SNAPSHOT"
-fabric-loader = "0.18.4"
+fabric-loom = "1.16-SNAPSHOT"
+fabric-loader = "0.18.6"
 mapping-io = "0.8.0"
 mixin = "0.8.5"
 moddev = "2.0.140"

--- a/metadata.toml
+++ b/metadata.toml
@@ -4,7 +4,7 @@ id = "freecam"
 group = "net.xolt.freecam"
 # Version can specify a semver pre-release, e.g. -alpha.1
 # Remember to run :changelog:patchChangelog when updating
-version = "1.4.0-alpha.2"
+version = "1.4.0-alpha.3"
 authors = ["hashalite", "Matt Sturgeon"]
 license = "MIT"
 homepage = "https://www.curseforge.com/minecraft/mc-mods/free-cam"

--- a/neoforge/src/main/java/net/xolt/freecam/forge/NeoforgePlatform.java
+++ b/neoforge/src/main/java/net/xolt/freecam/forge/NeoforgePlatform.java
@@ -1,0 +1,15 @@
+package net.xolt.freecam.forge;
+
+//? if neoforge: >=21
+import net.neoforged.fml.loading.FMLLoader;
+import net.neoforged.fml.loading.moddiscovery.ModInfo;
+import net.xolt.freecam.ModPlatform;
+
+public class NeoforgePlatform implements ModPlatform {
+
+    @Override
+    public boolean isModLoaded(String modId) {
+        //~ if neoforge: >=21 'net.neoforged.fml.loading.LoadingModList.get()' -> 'FMLLoader.getCurrent().getLoadingModList()'
+        return FMLLoader.getCurrent().getLoadingModList().getMods().stream().map(ModInfo::getModId).anyMatch(modId::equals);
+    }
+}

--- a/neoforge/src/main/resources/META-INF/services/net.xolt.freecam.ModPlatform
+++ b/neoforge/src/main/resources/META-INF/services/net.xolt.freecam.ModPlatform
@@ -1,0 +1,1 @@
+net.xolt.freecam.forge.NeoforgePlatform

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -39,11 +39,11 @@ deps.cloth = "26.1.154"
 cloth_config_req = "[26.1,26.2)"
 deps.modmenu = "18.0.0-alpha.8"
 
-deps.fabric_api = "0.144.0+26.1"
+deps.fabric_api = "0.145.4+26.1.2"
 fabric_loader_req = ">=0.18.0"
 fabric_mc_req = ">=26.1-rc-1"
 
-deps.neoforge_version = "26.1.0.1-beta"
+deps.neoforge_version = "26.1.2.2-beta"
 neoforge_req = "[26.1.0.0-alpha,)"
 neoforge_loader_req = "[1,)"
 neoforge_mc_req = "[26.1-rc-1,)"

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -33,6 +33,8 @@ modmenu.modrinth_id = "mOgUt4GM"
 
 
 ["26.1"]
+supported_mc_versions = ["26.1", "26.1.1", "26.1.2"]
+
 deps.cloth = "26.1.154"
 cloth_config_req = "[26.1,26.2)"
 deps.modmenu = "18.0.0-alpha.8"

--- a/stonecutter.settings.toml
+++ b/stonecutter.settings.toml
@@ -6,7 +6,7 @@ vcs = "26.1"
 
 # Gradle projects to build for the corresponding Minecraft version.
 [versions]
-"26.1" = ["cloth-config", "common", "fabric", "neoforge"]
+"26.1:26.1.2" = ["cloth-config", "common", "fabric", "neoforge"]
 "1.21.11" = ["cloth-config", "common", "fabric", "neoforge"]
 "1.20.6" = ["cloth-config", "common", "fabric", "neoforge"]
 "1.19.4" = ["cloth-config", "common", "fabric", "forge"]


### PR DESCRIPTION
- Bumped versions
- Fix Iris "show player" shadow integration using vanilla "should render" hook.
- Refactor dynamic mixins using "is mod ID loaded" instead of "is class loaded".
  - Introduced `ModPlatform` SPI interface to provide access to platform-specific APIs.
- Simplified fabric icon definition; fixes Prism Launcher rendering.
- Update the changelog and release `1.4.0-alpha.3`.
