### PR TITLE
build: stonecutter 0.9.1-beta.4 → 0.9.1-beta.5

### DIFF
--- a/build-logic/settings/src/main/kotlin/net/xolt/freecam/gradle/ModMetadataSettingsPlugin.kt
+++ b/build-logic/settings/src/main/kotlin/net/xolt/freecam/gradle/ModMetadataSettingsPlugin.kt
@@ -83,10 +83,7 @@ private class ProjectModMetadata(
     @OptIn(StonecutterExperimentalAPI::class)
     override val supportedMinecraftVersions: List<String> by lazy {
         requireStonecutter("supportedMinecraftVersions")
-            .properties
-            .rawOrNull("supported_mc_versions")
-            ?.asList()
-            ?.map { it.toString() }
+            .properties.rawOrNull("supported_mc_versions")?.to()
             ?: emptyList()
     }
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.3.0"
-stonecutter = "0.9.1-beta.4"
+stonecutter = "0.9.1-beta.5"
 fabric-loom = "1.16-SNAPSHOT"
 fabric-loader = "0.18.6"
 mapping-io = "0.8.0"

--- a/stonecutter.settings.toml
+++ b/stonecutter.settings.toml
@@ -1,5 +1,5 @@
 # See https://stonecutter.kikugie.dev/wiki/config/settings#data-driven-setup
-"$schema" = "https://codeberg.org/stonecutter/stonecutter/src/branch/0.8/tools/settings-schema.json"
+"$schema" = "https://stonecutter.kikugie.dev/settings-schema/latest.json"
 
 # The version used by "reset active project"
 vcs = "26.1"


### PR DESCRIPTION
- Adds `SCElement.to<T>()`
- Moves settings schema to kikugie.dev
