### PR TITLE
ci(publish): extract to reusable workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,44 +110,13 @@ jobs:
           ) >> "$GITHUB_STEP_SUMMARY"
 
   publish:
-    if: needs.prepare.outputs.do_release || github.event.pull_request
-    name: Publish ${{ github.event.pull_request && '(dry run)' || '' }}
+    if: github.event_name != 'push' || needs.prepare.outputs.do_release
+    name: Publish
+    uses: ./.github/workflows/publish.yaml
     needs:
       - prepare
       - build
-    runs-on: ubuntu-slim
-    timeout-minutes: 30
     permissions:
-      # Grant 'write' to create releases.
       contents: write
-
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: temurin
-
-      - name: Install release publisher
-        env:
-          version: ${{ needs.prepare.outputs.version }}
-        run: |
-          tar --extract --file="artifacts/publish-$version.tar"
-          echo "$PWD/publish-$version/bin" >> "$GITHUB_PATH"
-
-      - name: Publish release
-        env:
-          do_release: ${{ needs.prepare.outputs.do_release }}
-          GITHUB_TOKEN: ${{ needs.prepare.outputs.do_release && github.token || 'dummy-token' }}
-        run: |
-          args=( artifacts )
-          [ -n "$do_release" ] || {
-            echo "::notice::Doing a dry run release"
-            args+=( --dry-run )
-          }
-          publish "${args[@]}"
+    with:
+      dry-run: ${{ github.event_name != 'push' }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,63 @@
+name: Publish
+
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        description: Dry run
+        type: boolean
+        default: false
+    outputs: {}
+    secrets: {}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    name: ${{ inputs.dry-run && 'dry run' || 'Release' }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 30
+
+    permissions:
+      # Grant 'write' to create releases.
+      contents: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+
+      - name: Install release publisher
+        run: |
+          files=( artifacts/publish-*.tar )
+          [ ${#files[@]} = 1 ] || {
+            echo "::error::Found ${#files[@]} publish artifacts, expected 1"
+            exit 1
+          }
+          file="${files[0]}"
+          name=$(basename --suffix .tar "$file")
+          tar --extract --file="$file"
+          echo "$PWD/$name/bin" >> "$GITHUB_PATH"
+
+      - name: GitHub Release
+        env:
+          dry_run: ${{ inputs.dry-run || '' }}
+          GITHUB_TOKEN: ${{ inputs.dry-run && 'dummy-token' || github.token }}
+        run: |
+          args=( artifacts )
+          if [ -n "$dry_run" ]; then
+            echo "::notice::Doing a dry run release"
+            args+=( --dry-run )
+          fi
+          publish "${args[@]}"


### PR DESCRIPTION
Extract the publishing job to its own workflow. I plan to extend the workflow into a two-job workflow that publishes to GH Releases on job 1 and publishes to CurseForge & Modrinth on job 2. It'll also be possible to run job 2 `on: release` and/or `on: workflow_dispatch` for more modularity.

I'm also planning to move the `:publish` project into a separate repo, so that we can depend on a stable artifact instead of rebuilding it on every workflow run.
