### PR TITLE
ci(pr): manage i18n labels

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     with:
       changelog: true
+      i18n: true
 
 
   find_build:
@@ -254,4 +255,129 @@ jobs:
               repo,
               issue_number,
               body,
+            })
+
+  label:
+    name: Label
+    runs-on: ubuntu-slim
+    needs: [prepare]
+    timeout-minutes: 5
+
+    permissions:
+      issues: write # For managing labels
+      pull-requests: write # For managing PR labels
+
+    steps:
+      - name: Compute managed labels
+        shell: python
+        env:
+          i18n: ${{ needs.prepare.outputs.i18n_files }}
+        run: |
+          import json
+          import os
+
+          managed = ["i18n"]
+
+          labels = {
+            label: os.environ.get(label) == "true"
+            for label in managed
+          }
+
+          with open("labels.json", "w") as file:
+            json.dump(labels, file)
+
+      - name: Sync managed labels
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { readFileSync } = require("fs")
+            const { owner, repo } = context.repo
+            const issue_number = context.payload.pull_request.number
+            const botId = 41898282 // github-actions[bot]
+
+            const managed = JSON.parse(readFileSync("labels.json", "utf8"))
+
+            // Event history is only needed when un-setting labels
+            const needsHistory = Object.values(managed).some(present => !present)
+
+            // Get current labels
+            const current = (await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number,
+            })).data.map(label => label.name).sort()
+
+            // Build label history from timeline events
+            // label → latest add event
+            const lastAdded = await (async () => {
+              const result = new Map()
+
+              // Avoid API calls when we don't need history
+              if (!needsHistory) return result
+
+              const iterator = github.paginate.iterator(
+                github.rest.issues.listEventsForTimeline,
+                { owner, repo, issue_number, per_page: 100 }
+              )
+
+              for await (const { data } of iterator) {
+                for (const event of data) {
+                  if (event.event === "labeled" && event.actor) {
+                    const prev = result.get(event.label.name)
+                    const timestamp = Date.parse(event.created_at)
+                    if (!prev || timestamp > prev.timestamp) {
+                      result.set(event.label.name, {
+                        id: event.actor.id,
+                        login: event.actor.login,
+                        timestamp,
+                      })
+                    }
+                  }
+                }
+              }
+
+              return result
+            })()
+
+            // Compute next label set
+            const next = (() => {
+              const result = new Set(current)
+
+              for (const [label, shouldHaveLabel] of Object.entries(managed)) {
+                if (shouldHaveLabel) {
+                  result.add(label)
+                } else if (result.has(label)) {
+                  const event = lastAdded.get(label)
+
+                  // Only remove if last added by github-actions bot
+                  if (event?.id !== botId) {
+                    const ctx = event?.login
+                        ? `last added by ${event?.login}`
+                        : "unknown event"
+                    core.info(`Skipping removal of '${label}' (${ctx})`)
+                    continue
+                  }
+
+                  result.delete(label)
+                }
+              }
+
+              return [...result].sort()
+            })()
+
+            const unchanged =
+              next.length === current.length &&
+              next.every((label, i) => label === current[i])
+
+            if (unchanged) {
+              core.info("No label changes required")
+              return
+            }
+
+            core.info(`Updating labels: ${JSON.stringify(next)}`)
+            await github.rest.issues.setLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: next,
             })

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: Comment
+name: PR
 
 on:
   pull_request_target:
@@ -94,8 +94,8 @@ jobs:
 
             core.setOutput("id", workflow.id)
 
-  sync:
-    name: Sync
+  comment:
+    name: Comment
     runs-on: ubuntu-slim
     needs: [prepare, find_build]
     timeout-minutes: 15

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -7,6 +7,10 @@ on:
         description: Check whether a changelog comment should be posted
         type: boolean
         default: false
+      i18n:
+        description: Check whether i18n files were touched
+        type: boolean
+        default: false
       release:
         description: Check whether a release should be made
         type: boolean
@@ -25,6 +29,9 @@ on:
       changelog_comment:
         description: Whether to post a PR comment displaying the current changelog
         value: ${{ jobs.prepare.outputs.changelog_comment }}
+      i18n_files:
+        description: Whether the PR touches i18n files
+        value: ${{ jobs.prepare.outputs.i18n_files }}
       matrix:
         description: The build matrix
         value: ${{ jobs.prepare.outputs.matrix }}
@@ -41,6 +48,7 @@ env:
   scopes: >
     ${{ inputs.matrix && 'python ci' || '' }}
     ${{ inputs.changelog && 'files' || '' }}
+    ${{ inputs.i18n && 'files' || '' }}
 
 jobs:
   prepare:
@@ -60,6 +68,7 @@ jobs:
           steps.changed_files.outputs.changelog ||
           steps.check_release.outputs.unreleased
         }}
+      i18n_files: ${{ steps.changed_files.outputs.i18n }}
       matrix: ${{ steps.matrix.outputs.matrix }}
 
     steps:
@@ -126,7 +135,12 @@ jobs:
             if (files.some(f => f.path === "CHANGELOG.md")) {
               core.notice("This PR touches the changelog")
               core.setOutput("changelog", "true")
-            } else if (files.length === 100) {
+            }
+            if (files.some(f => f.path.startsWith("i18n/"))) {
+              core.notice("This PR touches i18n files")
+              core.setOutput("i18n", "true")
+            }
+            if (files.length === 100) {
               core.warning("PR has ≥100 files — file detection may be incomplete")
             }
 


### PR DESCRIPTION

Tested in https://github.com/MattSturgeon/Freecam/pull/20

Have the `pull_request_target` workflow also manage labels. Currently limited to just the `i18n` label, based on whether anything in the `i18n/` tree is touched by the PR.

Based on timeline events, if the label no longer applies and was last added by `github-actions[bot]`, then it is removed. If the label was last added by a non-bot user, it is never removed.

