### PR TITLE
build(metadata): tag dev versions as -SNAPSHOT

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -179,12 +179,14 @@ jobs:
             --output matrix.json
           )
 
-          # If 'unreleased' is set, that means the version has been bumped.
-          # Otherwise, we build the in-progress [Unreleased] changelog section.
+          # If 'unreleased' is set, that means the version has been bumped, so do a release build.
           if [ -n "$unreleased" ]; then
-            args+=( --release-changelog )
-          elif [ -n "$touches_changelog" ]; then
-            args+=( --unreleased-changelog )
+            args+=( --release )
+          fi
+
+          # For PRs that touch the changelog or trigger a release, we build the changelog preview comment.
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$touches_changelog$unreleased" ]; then
+              args+=( --changelog )
           fi
 
           node ci/src/build_matrix.ts "${args[@]}"

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -76,6 +76,12 @@ jobs:
         if: contains(env.scopes, 'node')
         uses: actions/checkout@v6
         with:
+          ref: >
+            ${{
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.head.sha ||
+              github.sha
+            }}
           sparse-checkout: |
             ci
             package.json
@@ -88,7 +94,6 @@ jobs:
         with:
           ref: >
             ${{
-              github.event.pull_request.merge_commit_sha ||
               github.event.pull_request.head.sha ||
               github.sha
             }}

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/ModMetadataPlugin.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/ModMetadataPlugin.kt
@@ -6,6 +6,7 @@ import net.xolt.freecam.model.elaborate
 import net.xolt.freecam.model.loadStaticMetadata
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
+import org.gradle.api.logging.Logging
 import org.gradle.kotlin.dsl.add
 
 class ModMetadataPlugin : Plugin<Settings> {
@@ -14,8 +15,18 @@ class ModMetadataPlugin : Plugin<Settings> {
         const val EXTENSION_NAME = "meta"
     }
 
+    private val logger = Logging.getLogger(ModMetadataPlugin::class.java)
+
     override fun apply(settings: Settings) = with(settings) {
-        val metadata = rootDir.resolve("metadata.toml").loadStaticMetadata()
+        val isRelease = providers.gradleProperty("isReleaseBuild")
+            .map { it.equals("true", ignoreCase = true) }
+            .getOrElse(false)
+
+        val metadata = rootDir.resolve("metadata.toml").loadStaticMetadata().let {
+            if (isRelease) it else it.copy(version = "${it.version}-SNAPSHOT")
+        }
+
+        logger.lifecycle("${metadata.name} version: ${metadata.version}")
 
         extensions.add<StaticModMetadata>(EXTENSION_NAME, metadata)
         gradle.settingsEvaluated {

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/StaticModMetadata.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/StaticModMetadata.kt
@@ -9,7 +9,7 @@ import java.io.File
 
 internal fun File.loadStaticMetadata(): StaticModMetadata {
     val metadata: MetadataToml = bufferedReader().use { reader ->
-        Toml.Default.decodeFromReader(TomlNativeReader(reader))
+        Toml.decodeFromReader(TomlNativeReader(reader))
     }
     return metadata.mod
 }

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/StaticModMetadata.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/StaticModMetadata.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.io.File
 
-internal fun File.loadStaticMetadata(): StaticModMetadata {
+internal fun File.loadStaticMetadata(): ModMetadataToml {
     val metadata: MetadataToml = bufferedReader().use { reader ->
         Toml.decodeFromReader(TomlNativeReader(reader))
     }
@@ -48,6 +48,6 @@ internal data class ModMetadataToml(
 ) : StaticModMetadata {
 
     override val releaseType: ReleaseType by lazy {
-        ReleaseType.fromVersion(version)
+        ReleaseType.fromVersion(version.removeSuffix("-SNAPSHOT"))
     }
 }

--- a/ci/src/build_matrix.test.ts
+++ b/ci/src/build_matrix.test.ts
@@ -60,7 +60,7 @@ describe("buildVersionMatrix", () => {
       ":fabric:1.20:buildAndCollect",
       ":forge:1.20:buildAndCollect",
     ]);
-    assert.equal(job120.upload?.name, "freecam-1.2.3-1.20");
+    assert.equal(job120.upload?.name, "mc-1.20");
   });
 });
 

--- a/ci/src/build_matrix.ts
+++ b/ci/src/build_matrix.ts
@@ -23,10 +23,9 @@ export function main(args: CliOptions) {
     loadVersions("versions", args.versionsFile),
   );
 
-  const changelogJobs =
-    args.changelogMode === "none"
-      ? []
-      : [buildChangelogJob(args.changelogMode === "release", version)];
+  const changelogJobs = args.changelog
+    ? [buildChangelogJob(args.release, version)]
+    : [];
 
   const staticJobs = args.jobsFile
     ? loadMatrixJobs("build", args.jobsFile)
@@ -35,6 +34,12 @@ export function main(args: CliOptions) {
   const matrix = [...changelogJobs, ...staticJobs, ...versionJobs].sort(
     (a, b) => a.name.localeCompare(b.name),
   );
+
+  if (args.release) {
+    matrix.forEach(({ gradle_args }) => {
+      gradle_args.push("-DisReleaseBuild=true");
+    });
+  }
 
   const output = JSON.stringify(matrix, null, 4);
 

--- a/ci/src/build_matrix.ts
+++ b/ci/src/build_matrix.ts
@@ -71,8 +71,8 @@ export function buildVersionMatrix(
         name: `MC ${entry.project}`,
         gradle_args: gradleArgs,
         upload: {
+          name: `mc-${entry.project}`,
           path: `build/libs/${version}/*.jar`,
-          name: `freecam-${version}-${entry.project}`,
         },
       }),
     );

--- a/ci/src/build_matrix.ts
+++ b/ci/src/build_matrix.ts
@@ -19,7 +19,7 @@ export function main(args: CliOptions) {
   const version = args.version ?? readVersion();
 
   const versionJobs = buildVersionMatrix(
-    version,
+    version + (args.release ? "" : "-SNAPSHOT"),
     loadVersions("versions", args.versionsFile),
   );
 

--- a/ci/src/build_matrix_cli.ts
+++ b/ci/src/build_matrix_cli.ts
@@ -18,8 +18,6 @@ const ExistingFile = z.string().refine(existsSync, {
 
 const JobsFileInput = z.union([z.literal("none"), ExistingFile]);
 
-const ChangelogFileInput = z.enum(["release", "unreleased", "none"]);
-
 function toRelative(p: string): string {
   return path.relative(process.cwd(), p);
 }
@@ -28,40 +26,16 @@ const VersionInput = Version.optional().transform(
   (v?: string | undefined) => v ?? readVersion(METADATA_FILE),
 );
 
-const CliOptionsSchema = z
-  .object({
-    versionsFile: ExistingFile,
-    jobsFile: JobsFileInput.transform((file: string) =>
-      file === "none" ? undefined : file,
-    ),
-    releaseChangelog: z.boolean().optional(),
-    unreleasedChangelog: z.boolean().optional(),
-    changelogMode: ChangelogFileInput,
-    version: VersionInput,
-    output: z.string().optional(),
-  })
-  .superRefine((v, ctx) => {
-    const modes = new Set(
-      [
-        v.releaseChangelog && "release",
-        v.unreleasedChangelog && "unreleased",
-        v.changelogMode !== "none" && v.changelogMode,
-      ].filter(Boolean),
-    );
-
-    if (modes.size > 1) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Conflicting changelog options: ${[...modes].join(", ")}`,
-      });
-    }
-  })
-  .transform((v) => {
-    let { changelogMode, releaseChangelog, unreleasedChangelog, ...rest } = v;
-    if (releaseChangelog) changelogMode = "release";
-    if (unreleasedChangelog) changelogMode = "unreleased";
-    return { ...rest, changelogMode };
-  });
+const CliOptionsSchema = z.object({
+  versionsFile: ExistingFile,
+  jobsFile: JobsFileInput.transform((file: string) =>
+    file === "none" ? undefined : file,
+  ),
+  release: z.boolean(),
+  changelog: z.boolean(),
+  version: VersionInput,
+  output: z.string().optional(),
+});
 
 export type CliOptions = z.infer<typeof CliOptionsSchema>;
 
@@ -90,24 +64,15 @@ export const command = buildCommand({
         default: toRelative(MATRIX_JOBS_FILE),
       },
 
-      releaseChangelog: {
-        brief: "Build changelog for --version (sets --changelog-mode=release)",
+      changelog: {
+        brief:
+          "Build changelog (current version if --release, otherwise unreleased)",
         kind: "boolean",
-        withNegated: false,
       },
 
-      unreleasedChangelog: {
-        brief: "Build unreleased changelog (sets --changelog-mode=unreleased)",
+      release: {
+        brief: "Build in release mode",
         kind: "boolean",
-        withNegated: false,
-      },
-
-      changelogMode: {
-        brief: "Changelog to build ('none', 'unreleased', 'release')",
-        placeholder: "mode",
-        kind: "parsed",
-        parse: ChangelogFileInput.parse,
-        default: "none",
       },
 
       version: {


### PR DESCRIPTION
- Add a `-SNAPSHOT` suffix to all builds, unless `isReleaseBuild=true` is set.
- CI sets `isReleaseBuild=true` only when doing a release build (a push or PR that bumps the mod version)
- Also remove mod version from CI artifact names; still present in the actual JAR names.