### PR TITLE
build: configure Gradle retries

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4G
-fabric.loom.multiProjectOptimisation=true
 
 # Internal repository retry settings
 # See https://github.com/gradle/gradle/issues/4629#issuecomment-1174938250

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,8 +2,9 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
 networkTimeout=10000
-retries=0
-retryBackOffMs=500
+retries=5
+# Initial backoff in milliseconds, doubled with each retry:
+retryBackOffMs=1000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The first commit configures retries for the wrapper download.
The second commit configures retries for repositories, via internal properties.

- https://docs.gradle.org/9.5.0/userguide/gradle_wrapper.html#sec:configuring_wrapper_retries
- https://docs.gradle.org/9.5.0/userguide/graph_resolution.html#sec:repository-disabling
- https://github.com/gradle/gradle/issues/4629#issuecomment-1174938250