### PR TITLE
build(metadata): store requirement constraints semantically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Removed
 
+- Support for Minecraft 1.21.10 ([482](https://github.com/MinecraftFreecam/Freecam/pull/482))
+
 ### Fixed
 
 - Marked 1.20.5 as supported by the 1.20.6 build ([436](https://github.com/MinecraftFreecam/Freecam/issues/436), [452](https://github.com/MinecraftFreecam/Freecam/pull/452))

--- a/build-logic/api/build.gradle.kts
+++ b/build-logic/api/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
 
 dependencies {
     api(libs.freecam.publish.schema)
+    api(libs.kotlin.semver)
     implementation(libs.kotlin.serialization.json)
 }

--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
@@ -1,11 +1,14 @@
 package net.xolt.freecam.model
 
+import io.github.z4kn4fein.semver.constraints.Constraint
+
 interface ModMetadata : StaticModMetadata {
     val mc: String
     val loader: String
     val description: String
     val mod: Map<String, String>
     val deps: Map<String, String>
+    val reqs: Map<String, Constraint>
     val relationships: List<Relationship>
     val supportedMinecraftVersions: List<String>
     val javaVersion: Int

--- a/build-logic/conventions/src/main/kotlin/build-extensions.kt
+++ b/build-logic/conventions/src/main/kotlin/build-extensions.kt
@@ -1,6 +1,7 @@
 import dev.kikugie.stonecutter.build.StonecutterBuildExtension
 import dev.kikugie.stonecutter.controller.StonecutterControllerExtension
 import dev.kikugie.stonecutter.data.tree.ProjectNode
+import io.github.z4kn4fein.semver.constraints.toMavenFormat
 import net.xolt.freecam.model.ModMetadata
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
@@ -47,12 +48,12 @@ val Project.commonExpansions: Map<String, String>
         "modModrinth" to meta.modrinthUrl.toString(),
         "modCrowdin" to meta.crowdinUrl.toString(),
         "neoForgeVersion" to meta.deps["neoforge_version"],
-        "neoforgeLoaderReq" to properties["neoforge_loader_req"] as? String,
-        "neoforgeReq" to properties["neoforge_req"] as? String,
-        "neoforgeMcReq" to properties["neoforge_mc_req"] as? String,
+        "neoforgeLoaderReq" to meta.reqs["neoforge_loader"]?.toMavenFormat(),
+        "neoforgeReq" to meta.reqs["neoforge_version"]?.toMavenFormat(),
+        "neoforgeMcReq" to meta.reqs["mc"]?.toMavenFormat(),
         "forgeVersion" to meta.deps["forge_version"],
-        "forgeLoaderReq" to properties["forge_loader_req"] as? String,
-        "forgeReq" to properties["forge_req"] as? String,
-        "forgeMcReq" to properties["forge_mc_req"] as? String,
-        "clothConfigReq" to properties["cloth_config_req"] as? String,
+        "forgeLoaderReq" to meta.reqs["forge_loader"]?.toMavenFormat(),
+        "forgeReq" to meta.reqs["forge_version"]?.toMavenFormat(),
+        "forgeMcReq" to meta.reqs["mc"]?.toMavenFormat(),
+        "clothConfigReq" to meta.reqs["cloth"]?.toMavenFormat(),
     ).filterValues { it?.isNotEmpty() == true }.mapValues { it.value!! }

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
@@ -2,6 +2,8 @@ package net.xolt.freecam.model
 
 import dev.kikugie.stonecutter.AnyVersion
 import dev.kikugie.stonecutter.build.StonecutterBuildExtension
+import io.github.z4kn4fein.semver.constraints.ConstraintFormatException
+import io.github.z4kn4fein.semver.constraints.toConstraint
 import net.xolt.freecam.util.decodeTomlPath
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.findByType
@@ -86,6 +88,15 @@ private class ProjectModMetadata(
 
     override val mod by lazy { project.properties.toPrefixMap("mod.") }
     override val deps by lazy { project.properties.toPrefixMap("deps.") }
+    override val reqs by lazy {
+        project.properties.toPrefixMap("reqs.").mapValues { (key, value) ->
+            try {
+                value.toConstraint()
+            } catch (e: ConstraintFormatException) {
+                error("${project.path} reqs.$key='$value': ${e.message}")
+            }
+        }
+    }
 }
 
 private fun Map<String, Any?>.toPrefixMap(prefix: String) =

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
@@ -84,35 +84,18 @@ private class ProjectModMetadata(
             .get()
     }
 
-    override val mod = PrefixedPropertyMap("mod.") { project.properties }
-    override val deps = PrefixedPropertyMap("deps.") { project.properties }
+    override val mod by lazy { project.properties.toPrefixMap("mod.") }
+    override val deps by lazy { project.properties.toPrefixMap("deps.") }
 }
 
-private class PrefixedPropertyMap(
-    private val prefix: String = "",
-    private val properties: () -> Map<String, Any?>,
-) : Map<String, String> {
-
-    private val map by lazy {
-        properties()
-            .asSequence()
-            .filter { (key, _) ->
-                key.startsWith(prefix)
-            }
-            .mapNotNull { (key, value) ->
-                (value as? String)?.let { key to it }
-            }
-            .associate { (key, value) ->
-                key.removePrefix(prefix) to value
-            }
-    }
-
-    override val size get() = map.size
-    override val keys get() = map.keys
-    override val values get() = map.values
-    override val entries get() = map.entries
-    override fun isEmpty() = map.isEmpty()
-    override fun containsKey(key: String) = map.containsKey(key)
-    override fun containsValue(value: String) = map.containsValue(value)
-    override fun get(key: String) = map[key]
-}
+private fun Map<String, Any?>.toPrefixMap(prefix: String) =
+    asSequence()
+        .filter { (key, _) ->
+            key.startsWith(prefix)
+        }
+        .mapNotNull { (key, value) ->
+            (value as? String)?.let { key to it }
+        }
+        .associate { (key, value) ->
+            key.removePrefix(prefix) to value
+        }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -116,8 +116,8 @@ tasks {
                 }
             }
 
-            depends("minecraft", sc.properties.get<String>("fabric_mc_req"))
-            depends("fabricloader", sc.properties.get<String>("fabric_loader_req"))
+            depends("minecraft", meta.reqs["mc"]?.toString() ?: error("${project.path} missing reqs.mc"))
+            depends("fabricloader", meta.reqs["fabric_loader"]?.toString() ?: error("${project.path} missing reqs.fabric_loader"))
             depends(if (sc.current.parsed < "1.19.2") "fabric" else "fabric-api", "*")
             recommends("modmenu", "*")
 

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.z4kn4fein.semver.constraints.toMavenFormat
 import net.neoforged.moddevgradle.legacyforge.internal.MinecraftMappings
 
 plugins {
@@ -71,13 +72,16 @@ dependencies {
         val clothVersion = requireNotNull(meta.deps["cloth"]) {
             "Missing deps.cloth for ${project.path}"
         }
+        val clothConstraint = requireNotNull(meta.reqs["cloth"]) {
+            "Missing reqs.cloth for ${project.path}"
+        }
         // `jarJar` requires a SRG dependency, which we don't have for `:cloth-config`.
         // Instead, we can include named-classes in jar and reobfJar will remap them.
         bundle(implementation(project(path = it.project.path, configuration = "namedElements"))!!)
         include(modImplementation("me.shedaniel.cloth:cloth-config-forge") {
             version {
                 prefer(clothVersion)
-                strictly(sc.properties["cloth_config_req"])
+                strictly(clothConstraint.toMavenFormat())
             }
         })
     } ?: logger.warn("No :cloth-config project for ${project.path}")

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -10,6 +10,7 @@ moddev = "2.0.140"
 fletchingtable = "0.1.0-alpha.23"
 foojay-resolver = "1.0.0"
 tomlkt = "0.6.0"
+semver = "3.1.0"
 jetbrains-changelog = "2.5.0"
 serialization-json = "1.10.0"
 coroutines = "1.10.2"
@@ -21,6 +22,7 @@ freecam-publish-schema = { group = "com.github.MinecraftFreecam.Publisher", name
 fabric-loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabric-loader"}
 mapping-io = { group = "net.fabricmc", name = "mapping-io", version.ref = "mapping-io"}
 sponge-mixin = { group = "org.spongepowered", name = "mixin", version.ref = "mixin" }
+kotlin-semver = { group = "io.github.z4kn4fein", name = "semver", version.ref = "semver" }
 kotlin-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization-json" }
 kotlin-serialization-toml = { group = "dev.eav.tomlkt", name = "tomlkt", version.ref = "tomlkt" }
 kotlin-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -1,3 +1,5 @@
+import io.github.z4kn4fein.semver.constraints.toMavenFormat
+
 plugins {
     alias(libs.plugins.moddev)
     alias(libs.plugins.fletchingtable.neoforge)
@@ -23,11 +25,14 @@ dependencies {
         val clothVersion = requireNotNull(meta.deps["cloth"]) {
             "Missing deps.cloth for ${project.path}"
         }
+        val clothConstraint = requireNotNull(meta.reqs["cloth"]) {
+            "Missing reqs.cloth for ${project.path}"
+        }
         jarJar(implementation(project(path = it.project.path, configuration = "namedElements")) as Any)
         jarJar(implementation("me.shedaniel.cloth:cloth-config-neoforge") {
             version {
                 prefer(clothVersion)
-                strictly(sc.properties["cloth_config_req"])
+                strictly(clothConstraint.toMavenFormat())
             }
         })
     } ?: logger.warn("No :cloth-config project for ${project.path}")

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -48,11 +48,10 @@ reqs.neoforge_loader = ">=1"
 
 
 ["1.21.11"]
-reqs.mc = "~1.21.10"
+reqs.mc = "1.21.11"
 
 deps.cloth = "21.11.153"
 reqs.cloth = "~21.11"
-supported_mc_versions = ["1.21.10"]
 
 deps.fabric_api = "0.139.4+1.21.11"
 deps.modmenu = "17.0.0-beta.2"

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -6,6 +6,14 @@
 # Tags can be added via `sc.properties.tags()`.
 #
 # Resolved property paths are stringified as a dotted property keys.
+#
+# `reqs` versions are parsed as semver constraints, while `deps` are exact versions:
+#   https://github.com/z4kn4fein/kotlin-semver#constraints
+#
+# Fabric: https://fabricmc.net/develop
+# NeoForge: https://projects.neoforged.net/neoforged/neoforge
+# Cloth Config: https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config
+# ModMenu: https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu
 
 
 [relationship]
@@ -23,129 +31,116 @@ modmenu.curseforge_slug = "modmenu"
 modmenu.modrinth_id = "mOgUt4GM"
 
 
-# Cloth Config: https://mvnrepository.com/artifact/me.shedaniel.cloth/cloth-config
-# ModMenu: https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu
-# NeoForge project: https://projects.neoforged.net/neoforged/neoforge
-# Fabric version range syntax:
-# https://wiki.fabricmc.net/documentation:fabric_mod_json_spec
-# Forge and NeoForge uses Maven version ranges:
-# https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
-
-
 ["26.1"]
 supported_mc_versions = ["26.1", "26.1.1", "26.1.2"]
+reqs.mc = "~26.1"
 
 deps.cloth = "26.1.154"
-cloth_config_req = "[26.1,26.2)"
+reqs.cloth = "~26.1"
 deps.modmenu = "18.0.0-alpha.8"
 
 deps.fabric_api = "0.145.4+26.1.2"
-fabric_loader_req = ">=0.18.0"
-fabric_mc_req = ">=26.1-rc-1"
+reqs.fabric_loader = ">=0.18.0"
 
 deps.neoforge_version = "26.1.2.2-beta"
-neoforge_req = "[26.1.0.0-alpha,)"
-neoforge_loader_req = "[1,)"
-neoforge_mc_req = "[26.1-rc-1,)"
+reqs.neoforge_version = ">=26.1.0-alpha"
+reqs.neoforge_loader = ">=1"
 
 
 ["1.21.11"]
+reqs.mc = "~1.21.10"
+
 deps.cloth = "21.11.153"
-cloth_config_req = "[21.11,21.12)"
+reqs.cloth = "~21.11"
 supported_mc_versions = ["1.21.10"]
 
 deps.fabric_api = "0.139.4+1.21.11"
 deps.modmenu = "17.0.0-beta.2"
-fabric_mc_req = "~1.21.10"
-fabric_loader_req = ">=0.14.0"
+reqs.fabric_loader = ">=0.14.0"
 
 deps.neoforge_version = "21.11.6-beta"
 deps.neoforge_pr = ""
-neoforge_req = "[21.9.0-beta,)"
-neoforge_loader_req = "[1,)"
-neoforge_mc_req = "[1.21.10,1.21.11]"
+reqs.neoforge_version = ">=21.9.0-beta"
+reqs.neoforge_loader = ">=1"
 
 
 ["1.20.6"]
 deps.cloth = "14.0.126"
-cloth_config_req = "[14,15)"
+reqs.cloth = "^14"
 
 deps.fabric_api = "0.100.8+1.20.6"
 deps.modmenu = "10.0.0"
-fabric_mc_req = "~1.20.5"
-fabric_loader_req = ">=0.14.0"
+reqs.fabric_loader = ">=0.14.0"
 
 deps.neoforge_version = "20.6.139"
 deps.neoforge_pr = ""
-neoforge_req = "[20.6.11-beta,)"
-neoforge_loader_req = "[1,)"
-neoforge_mc_req = "[1.20.6,1.21)"
+reqs.neoforge_version = ">=20.6.11-beta"
+reqs.neoforge_loader = ">=1"
 
 fabric.supported_mc_versions = ["1.20.5"]
+fabric.reqs.mc = "~1.20.5"
+neoforge.reqs.mc = "~1.20.6"
 
 
 ["1.19.4"]
+reqs.mc = "~1.19.4"
 deps.cloth = "10.1.117"
-cloth_config_req = "[10.1,11)"
+reqs.cloth = "^10.1"
 
 deps.fabric_api = "0.87.2+1.19.4"
 deps.modmenu = "6.3.1"
-fabric_mc_req = "~1.19.4"
-fabric_loader_req = ">=0.12.11"
+reqs.fabric_loader = ">=0.12.11"
 
 deps.forge_version = "45.2.6"
-forge_req = "[45,)"
-forge_loader_req = "[45,)"
-forge_mc_req = "[1.19.4,1.20)"
+reqs.forge_version = ">=45"
+reqs.forge_loader = ">=45"
 
 
 ["1.18.2"]
+reqs.mc = "~1.18.2"
 deps.cloth = "6.5.102"
-cloth_config_req = "[6,7)"
+reqs.cloth = "^6"
 
 deps.fabric_api = "0.77.0+1.18.2"
 deps.modmenu = "3.2.5"
-fabric_mc_req = "~1.18.2"
-fabric_loader_req = ">=0.12.11"
+reqs.fabric_loader = ">=0.12.11"
 
 deps.forge_version = "40.2.14"
-forge_req = "[40,)"
-forge_loader_req = "[40,)"
-forge_mc_req = "[1.18.2,1.19)"
+reqs.forge_version = ">=40"
+reqs.forge_loader = ">=40"
 
 
 ["1.17.1"]
 deps.cloth = "5.3.63"
-cloth_config_req = "[5,6)"
+reqs.cloth = "^5"
 
 deps.fabric_api = "0.46.1+1.17"
 deps.modmenu = "2.0.17"
-fabric_mc_req = "~1.17"
-fabric_loader_req = ">=0.12.11"
+reqs.fabric_loader = ">=0.12.11"
 
 deps.forge_version = "37.1.1"
-forge_req = "[37,)"
-forge_loader_req = "[37,)"
-forge_mc_req = "[1.17.1,1.18)"
+reqs.forge_version = ">=37"
+reqs.forge_loader = ">=37"
 
 fabric.supported_mc_versions = ["1.17"]
+fabric.reqs.mc = "~1.17"
+forge.reqs.mc = "~1.17.1"
 
 forge.relationship.cloth-config.type = "optional"
 
 
 ["1.16.5"]
 supported_mc_versions = ["1.16.2", "1.16.3", "1.16.4"]
+reqs.mc = "~1.16.2"
 
 deps.cloth = "4.17.101"
 
 deps.fabric_api = "0.42.0+1.16"
 deps.modmenu = "1.16.23"
-fabric_mc_req = "~1.16.2"
-fabric_loader_req = ">=0.12.11"
+reqs.fabric_loader = ">=0.12.11"
 
 deps.forge_version = "36.2.41"
-forge_req = "[34,)"
-forge_loader_req = "[34,)"
-forge_mc_req = "[1.16.2,1.17)"
+reqs.forge_version = ">=34"
+reqs.forge_loader = ">=34"
 
 forge.relationship.cloth-config.type = "optional"


### PR DESCRIPTION

- Normalize all version constraints in `stonecutter.properties.toml` to semver syntax.
- Parse all `reqs` constraints as semantic [`Constraint`](https://z4kn4fein.github.io/kotlin-semver/semver/io.github.z4kn4fein.semver.constraints/-constraint/index.html) objects in `ModMetadata`.
- Render `Constraint`s using [`toString()`](https://z4kn4fein.github.io/kotlin-semver/semver/io.github.z4kn4fein.semver.constraints/-constraint/to-string.html) and [`toMavenFormat()`](https://z4kn4fein.github.io/kotlin-semver/semver/io.github.z4kn4fein.semver.constraints/to-maven-format.html), as appropriate.

I also tested each of our `supported_mc_versions` claims, and found that our `1.21.11` build does _not_ actually work on `1.21.10`. Therefore, I've dropped support for `1.21.10`.