### PR TITLE
fix(config): update config after GSON loads fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 ### Fixed
 
 - Marked 1.20.5 as supported by the 1.20.6 build ([436](https://github.com/MinecraftFreecam/Freecam/issues/436), [452](https://github.com/MinecraftFreecam/Freecam/pull/452))
+- Collision settings not being initialized correctly ([496](https://github.com/MinecraftFreecam/Freecam/issues/496), [497](https://github.com/MinecraftFreecam/Freecam/issues/497))
 
 ## [1.4.0-alpha.3] - 2026-04-10
 

--- a/common/src/main/java/net/xolt/freecam/config/controller/SingletonModConfigController.java
+++ b/common/src/main/java/net/xolt/freecam/config/controller/SingletonModConfigController.java
@@ -41,6 +41,9 @@ final class SingletonModConfigController implements ConfigController<ModConfigDT
             LOGGER.error("Failed to load config, using defaults", e);
             config = new ModConfigDTO();
         }
+        // ModConfigDTO calls onConfigChange when constructed,
+        // but GSON sets fields after constructing the object.
+        config.onConfigChange();
     }
 
     @Override


### PR DESCRIPTION
`ModConfigDTO` calls `onConfigChange` when constructed, but GSON sets fields _after_ constructing the `config` object.

Call `onConfigChange` again once GSON is finished loading.

Fixes #496
