### PR TITLE
fix: use player rotation when interacting as player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- Player-targeted block incorrectly using the camera's rotation ([438](https://github.com/MinecraftFreecam/Freecam/issues/438), [498](https://github.com/MinecraftFreecam/Freecam/pull/498))
 - Marked 1.20.5 as supported by the 1.20.6 build ([436](https://github.com/MinecraftFreecam/Freecam/issues/436), [452](https://github.com/MinecraftFreecam/Freecam/pull/452))
 
 ## [1.4.0-alpha.3] - 2026-04-10

--- a/common/src/main/java/net/xolt/freecam/mixins/GameRendererMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/GameRendererMixin.java
@@ -36,7 +36,7 @@ public class GameRendererMixin {
     // Moved to Minecraft#pick in 26.1
     //? if <26.1 {
     /*@ModifyVariable(method = "pick(F)V", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/Minecraft;getCameraEntity()Lnet/minecraft/world/entity/Entity;"))
-    private Entity onUpdateTargetedEntity(Entity entity) {
+    private Entity onGetHitTargetSource(Entity entity) {
         if (Freecam.isEnabled() && (Freecam.isPlayerControlEnabled() || ModConfig.get().allowInteractionsFromPlayer())) {
             return MC.player;
         }

--- a/common/src/main/java/net/xolt/freecam/mixins/LocalPlayerMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/LocalPlayerMixin.java
@@ -1,6 +1,7 @@
 package net.xolt.freecam.mixins;
 
 import net.xolt.freecam.Freecam;
+import net.xolt.freecam.config.ModConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,17 +23,19 @@ public class LocalPlayerMixin {
         }
     }
 
-    // Makes arm movement depend upon FreeCamera movement rather than player movement.
+    // Makes rotation depend upon FreeCamera rather than the player.
     @Inject(method = "getViewXRot", at = @At("HEAD"), cancellable = true)
     private void onGetViewXRot(float partialTick, CallbackInfoReturnable<Float> cir) {
-        if (Freecam.isEnabled())
+        if (Freecam.isEnabled() && !Freecam.isPlayerControlEnabled() && !ModConfig.get().allowInteractionsFromPlayer()) {
             cir.setReturnValue(Freecam.getFreeCamera().getViewXRot(partialTick));
+        }
     }
 
-    // Makes arm movement depend upon FreeCamera movement rather than player movement.
+    // Makes rotation depend upon FreeCamera rather than the player.
     @Inject(method = "getViewYRot", at = @At("HEAD"), cancellable = true)
     private void onGetViewYRot(float partialTick, CallbackInfoReturnable<Float> cir) {
-        if (Freecam.isEnabled())
+        if (Freecam.isEnabled() && !Freecam.isPlayerControlEnabled() && !ModConfig.get().allowInteractionsFromPlayer()) {
             cir.setReturnValue(Freecam.getFreeCamera().getViewYRot(partialTick));
+        }
     }
 }

--- a/common/src/main/java/net/xolt/freecam/mixins/MinecraftMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/MinecraftMixin.java
@@ -42,7 +42,7 @@ public class MinecraftMixin {
     // Was GameRenderer#pick before 26.1
     //? if >=26.1 {
     @ModifyVariable(method = "pick(F)V", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/Minecraft;getCameraEntity()Lnet/minecraft/world/entity/Entity;"))
-    private Entity onUpdateTargetedEntity(Entity entity) {
+    private Entity onGetHitTargetSource(Entity entity) {
         if (Freecam.isEnabled() && (Freecam.isPlayerControlEnabled() || ModConfig.get().allowInteractionsFromPlayer())) {
             return MC.player;
         }


### PR DESCRIPTION
When player control is enabled or `allowInteractionFromPlayer` is true, avoid overriding player rotation.

This fixes the player-targeted block using the camera's rotation (fixes #438).
