### PR TITLE
fix(CameraMixin): null-check `entity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- A crash when changing dimensions while Freecam is enabled ([505](https://github.com/MinecraftFreecam/Freecam/pull/505), [500](https://github.com/MinecraftFreecam/Freecam/issues/500))
+
 ## [1.4.0-rc.1] - 2026-05-26
 
 This version includes major underlying changes. Feedback and bug reports are greatly appreciated!

--- a/common/src/main/java/net/xolt/freecam/mixins/CameraMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/CameraMixin.java
@@ -28,6 +28,10 @@ public class CameraMixin {
     //? if >=26.1 {
     @Inject(method = "setEntity", at = @At("HEAD"))
     private void onSetEntity(Entity entity, CallbackInfo ci) {
+        if (entity == null || this.entity == null) {
+            return;
+        }
+
         if (entity instanceof FreeCamera || this.entity instanceof FreeCamera) {
             this.eyeHeightOld = this.eyeHeight = entity.getEyeHeight();
         }

--- a/common/src/main/java/net/xolt/freecam/mixins/CameraMixin.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/CameraMixin.java
@@ -35,13 +35,13 @@ public class CameraMixin {
     //? } else {
     /*@Inject(method = "setup", at = @At("HEAD"))
     //~ if >=1.21.11 'BlockGetter area' -> 'Level level'
-    public void onUpdate(Level level, Entity newFocusedEntity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci) {
-        if (newFocusedEntity == null || this.entity == null || newFocusedEntity.equals(this.entity)) {
+    public void onUpdate(Level level, Entity entity, boolean thirdPerson, boolean inverseView, float tickDelta, CallbackInfo ci) {
+        if (entity == null || this.entity == null || entity.equals(this.entity)) {
             return;
         }
 
-        if (newFocusedEntity instanceof FreeCamera || this.entity instanceof FreeCamera) {
-            this.eyeHeightOld = this.eyeHeight = newFocusedEntity.getEyeHeight();
+        if (entity instanceof FreeCamera || this.entity instanceof FreeCamera) {
+            this.eyeHeightOld = this.eyeHeight = entity.getEyeHeight();
         }
     }
     *///? }


### PR DESCRIPTION

Fixes #500, port the pre-26.1 null check to the 26.1+ mixin.

I noticed that this results in the "pose change" animation playing on dimension change, but that's better than a crash!
