### PR TITLE
ci(dependabot): group npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     commit-message:
       prefix: build
       prefix-development: ci
+    groups:
+      npm:
+        patterns: ["*"]
   - package-ecosystem: gradle
     directory: /
     schedule:


### PR DESCRIPTION
These are less individually critical than GH Actions or Gradle build deps, so group them to reduce noise and review toil.