### PR TITLE
fix(cloth-config): specify fabric mod-library metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- Resolved Fabric Loader "invalid version" warnings related to our Cloth Config implementation ([486](https://github.com/MinecraftFreecam/Freecam/issues/486), [534](https://github.com/MinecraftFreecam/Freecam/pull/534))
+
 ## [1.4.1-beta.1] - 2026-06-26
 
 1.4.1 adds initial support for Minecraft 26.2. Feedback and bug reports are greatly appreciated!

--- a/cloth-config/build.gradle.kts
+++ b/cloth-config/build.gradle.kts
@@ -1,3 +1,5 @@
+import net.fabricmc.loom.task.FabricModJsonV1Task
+
 plugins {
     alias(libs.plugins.fletchingtable.fabric)
     id("freecam.loom-adapter")
@@ -14,11 +16,45 @@ dependencies {
     modCompileOnly("me.shedaniel.cloth:cloth-config-fabric:${meta.deps["cloth"]}")
 }
 
-tasks.jar {
-    // `GAMELIBRARY` is required to access Minecraft classes from ModLauncher 9 (1.17)
-    val modType = if (sc.current.parsed >= "1.17") "GAMELIBRARY" else "LIBRARY"
-    manifest.attributes(
-        "FMLModType" to modType,
-        "Automatic-Module-Name" to "freecam.clothconfig",
-    )
+tasks {
+    // A fabric.mod.json file is required for fabricloader to know the library's `version`
+    val modJsonTask = register<FabricModJsonV1Task>("generateModJson") {
+        description = "Generate fabric.mod.json"
+
+        outputFile = layout.buildDirectory.dir("generated-mod-json").map {
+            it.file("fabric.mod.json")
+        }
+
+        json {
+            modId = "${meta.id}-cloth-config"
+            name = "${meta.name} Cloth Config GUI"
+            version = meta.version
+            description = "Provides a ${meta.name} Config GUI when Cloth Config is installed."
+            licenses = listOf(meta.license)
+
+            client()
+            // Currently bundled with Freecam, no need to specify a dependency
+            // recommends("cloth-config", meta.reqs["cloth"].toString())
+
+            customData = mapOf(
+                "modmenu" to mapOf(
+                    "parent" to meta.id,
+                    "badges" to listOf("library"),
+                ),
+            )
+        }
+    }
+
+    processResources {
+        from(modJsonTask)
+    }
+
+    jar {
+        // `GAMELIBRARY` is required to access Minecraft classes from ModLauncher 9 (1.17)
+        val modType = if (sc.current.parsed >= "1.17") "GAMELIBRARY" else "LIBRARY"
+        manifest.attributes(
+            "FMLModType" to modType,
+            "Automatic-Module-Name" to "${meta.id}.clothconfig",
+        )
+    }
 }


### PR DESCRIPTION
This tells Fabric Loader and ModMenu how to handle our Cloth Config implementation.

In particular, it resolves "invalid version" logs where Fabric Loader tries to infer a modid and version from the jar filename.

Fixes #486

