### PR TITLE
feat(fabric): drop fabric-api dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Removed
 
+- Dropped dependency on Fabric API ([537](https://github.com/MinecraftFreecam/Freecam/pull/537))
+  - The required modules are now distributed with Freecam.
+
 ### Fixed
 
 - Resolved Fabric Loader "invalid version" warnings related to our Cloth Config implementation ([486](https://github.com/MinecraftFreecam/Freecam/issues/486), [534](https://github.com/MinecraftFreecam/Freecam/pull/534))

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,4 +1,5 @@
 import net.fabricmc.loom.task.FabricModJsonV1Task
+import org.gradle.kotlin.dsl.sc
 
 plugins {
     alias(libs.plugins.fletchingtable.fabric)
@@ -21,25 +22,34 @@ stonecutter replacements {
     }
 }
 
+val fabricApiModules =  buildList {
+    val mc = sc.current.parsed
+    sequenceOf(
+        "fabric-api-base",
+        "fabric-lifecycle-events-v1",
+    ).forEach(::add)
+    when {
+        mc >= "1.21.9" -> add("fabric-resource-loader-v1")
+        else -> add("fabric-resource-loader-v0")
+    }
+    when {
+        mc >= "26.1" -> add("fabric-key-mapping-api-v1")
+        else -> add("fabric-key-binding-api-v1")
+    }
+    sort()
+}
+
+val fabricApiVersion = requireNotNull(meta.deps["fabric_api"]) {
+    "Missing deps.fabric_api for ${project.path}"
+}
+
 dependencies {
     minecraft("com.mojang:minecraft:${meta.mc}")
     loomAdapter.applyMojangMappings()
     modImplementation(libs.fabric.loader)
 
-    val fabricApiVersion = requireNotNull(meta.deps["fabric_api"]) {
-        "Missing deps.fabric_api for ${project.path}"
-    }
-
-    sequenceOf(
-        "fabric-lifecycle-events-v1",
-        if (sc.current.parsed >= "26.1") "fabric-key-mapping-api-v1"
-        else "fabric-key-binding-api-v1",
-    ).map { name ->
-        fabricApi.module(name, fabricApiVersion)
-    }.forEach { module ->
-        // TODO: include via jar-in-jar and drop `requires: fabric-api` from fabric.mod.json.
-        // include(module)
-        modImplementation(module)
+    fabricApiModules.forEach { name ->
+        include(modImplementation(fabricApi.module(name, fabricApiVersion))!!)
     }
 
     // Note: cloth-config and our fabric.mod.json require the entire fabric-api at runtime
@@ -56,11 +66,11 @@ dependencies {
         include(it.project)
         api(project(path = it.project.path, configuration = "namedElements"))
 
-        include("me.shedaniel.cloth:cloth-config-fabric:${meta.deps["cloth"]}")
-        modApi("me.shedaniel.cloth:cloth-config-fabric:${meta.deps["cloth"]}") {
+        include(modApi("me.shedaniel.cloth:cloth-config-fabric") {
+            version { prefer(meta.deps["cloth"]!!) }
             exclude(module = "fabric-api")
             exclude(module = "fabric-loader")
-        }
+        })
     } ?: logger.warn("No :cloth-config project for ${project.path}")
 }
 
@@ -125,7 +135,7 @@ tasks {
 
             depends("minecraft", meta.reqs["mc"]?.toString() ?: error("${project.path} missing reqs.mc"))
             depends("fabricloader", meta.reqs["fabric_loader"]?.toString() ?: error("${project.path} missing reqs.fabric_loader"))
-            depends(if (sc.current.parsed < "1.19.2") "fabric" else "fabric-api", "*")
+            fabricApiModules.forEach { depends(it, "*") }
             recommends("modmenu", "*")
 
             contactInformation = mapOf(

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -23,9 +23,6 @@ cloth-config.modrinth_id = "9s6osm5g"
 
 
 [fabric.relationship]
-fabric-api.type = "required"
-fabric-api.curseforge_slug = "fabric-api"
-fabric-api.modrinth_id = "P7dR8mSH"
 modmenu.type = "optional"
 modmenu.curseforge_slug = "modmenu"
 modmenu.modrinth_id = "mOgUt4GM"


### PR DESCRIPTION
Bundle the required fabric-api modules jar-in-jar and drop explicit dependency on `fabric-api: *`.

I had thought this wasn't possible, because `cloth-config` specifies a dependency on `fabric-api` itself (rather than a specific module). However, in testing it seems to work fine.
Maybe fabric-loader doesn't actually check the requirements of bundled jar-in-jar mods? I tested this with a few fabric-loader versions, just to be sure, and found no issues (back to fabricloader 1.14.0).


