### PR TITLE
build(meta): include git rev in snapshot versions

### DIFF
--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/ModMetadata.kt
@@ -1,5 +1,6 @@
 package net.xolt.freecam.model
 
+import io.github.z4kn4fein.semver.Version
 import io.github.z4kn4fein.semver.constraints.Constraint
 
 interface ModMetadata : StaticModMetadata {
@@ -18,7 +19,9 @@ interface StaticModMetadata {
     val id: String
     val name: String
     val group: String
-    val version: String
+    val releaseVersion: Version
+    val version: Version
+    val buildDir: String
     val releaseType: ReleaseType
     val authors: List<String>
     val license: String

--- a/build-logic/conventions/src/main/kotlin/build-extensions.kt
+++ b/build-logic/conventions/src/main/kotlin/build-extensions.kt
@@ -35,7 +35,7 @@ val Project.commonExpansions: Map<String, String>
         "mixinCompatLevel" to "JAVA_${meta.javaVersion}",
         "modId" to meta.id,
         "modName" to meta.name,
-        "modVersion" to meta.version,
+        "modVersion" to meta.version.toString(),
         "modGroup" to meta.group,
         "modAuthors" to meta.authors.joinToString(", "),
         "modDescription" to meta.description,

--- a/build-logic/metadata/build.gradle.kts
+++ b/build-logic/metadata/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(libs.kotlin.serialization.toml)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotest.assertions)
+    testImplementation(libs.mockk)
 }
 
 gradlePlugin {

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/CommandRunner.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/CommandRunner.kt
@@ -1,0 +1,33 @@
+package net.xolt.freecam.gradle
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.process.ProcessExecutionException
+import java.io.File
+
+internal fun interface CommandRunner {
+    fun run(directory: File, vararg args: String): Result?
+
+    operator fun invoke(directory: File, vararg args: String): Result? =
+        run(directory, *args)
+
+    data class Result(val exitCode: Int, val stdout: String?, val stderr: String?)
+}
+
+internal class GradleCommandRunner(private val providers: ProviderFactory) : CommandRunner {
+    override fun run(directory: File, vararg args: String): CommandRunner.Result? = try {
+        val exec = providers.exec {
+            workingDir(directory)
+            commandLine(*args)
+            isIgnoreExitValue = true
+        }
+        CommandRunner.Result(
+            exitCode = exec.result.get().exitValue,
+            stdout = exec.standardOutput.asText.orNull,
+            stderr = exec.standardError.asText.orNull,
+        )
+    } catch (_: ProcessExecutionException) {
+        // ProcessExecutionException occurs when the command can't be executed,
+        // typically because git isn't on the PATH
+        null
+    }
+}

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/GitRepository.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/GitRepository.kt
@@ -1,0 +1,45 @@
+package net.xolt.freecam.gradle
+
+import java.io.File
+
+internal data class GitMetadata(
+    val revision: String,
+    val isDirty: Boolean,
+)
+
+internal class GitRepository(
+    private val projectDir: File,
+    private val cmd: CommandRunner,
+) {
+    /**
+     * @return [Result] containing [GitMetadata] for success, or [Result.Failure] for expected errors
+     * @throws IllegalStateException for unexpected errors
+     */
+    fun resolveMetadata(): Result<GitMetadata> {
+        // First, check we are "in" the right git repo
+        cmd(projectDir, "git", "rev-parse", "--show-toplevel")?.apply {
+            if (exitCode == 128 && stderr?.startsWith("fatal: not a git repository") == true) {
+                return Result.failure(IllegalStateException("Not a git repository"))
+            }
+
+            if (exitCode != 0) error("Unknown git error ($exitCode): $stderr")
+
+            val workTree = stdout?.trim()?.let(::File)
+                ?: error("Error checking git toplevel")
+            if (projectDir.canonicalFile != workTree.canonicalFile) {
+                return Result.failure(IllegalStateException("Git repo ($workTree) is not project ($projectDir)."))
+            }
+        } ?: return Result.failure(IllegalStateException("Could not execute git"))
+
+        val head = cmd(projectDir, "git", "rev-parse", "--short", "HEAD")?.stdout?.trim()
+            ?: error("Error parsing git HEAD of $projectDir")
+
+        val status = cmd(projectDir, "git", "status", "--porcelain")?.stdout?.trim()
+            ?: error("Error getting git status for $projectDir")
+
+        return Result.success(GitMetadata(
+            revision = head,
+            isDirty = status.isNotBlank(),
+        ))
+    }
+}

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/ModMetadataPlugin.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/gradle/ModMetadataPlugin.kt
@@ -1,5 +1,6 @@
 package net.xolt.freecam.gradle
 
+import io.github.z4kn4fein.semver.Version
 import net.xolt.freecam.model.ModMetadata
 import net.xolt.freecam.model.StaticModMetadata
 import net.xolt.freecam.model.elaborate
@@ -7,38 +8,35 @@ import net.xolt.freecam.model.loadStaticMetadata
 import net.xolt.freecam.util.withSuffix
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
+import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.kotlin.dsl.add
+import javax.inject.Inject
 
-class ModMetadataPlugin : Plugin<Settings> {
+class ModMetadataPlugin(
+    private val logger: Logger,
+) : Plugin<Settings> {
+
+    @Inject constructor() : this(
+        logger = Logging.getLogger(ModMetadataPlugin::class.java),
+    )
 
     companion object {
         const val EXTENSION_NAME = "meta"
     }
 
-    private val logger = Logging.getLogger(ModMetadataPlugin::class.java)
-
     override fun apply(settings: Settings) = with(settings) {
-        val isRelease = providers.gradleProperty("isReleaseBuild").orNull
-            ?.trim()
-            ?.takeUnless { it.isEmpty() }
-            ?.lowercase()
-            ?.let {
-                when (it) {
-                    "true" -> true
-                    "false" -> false
-                    else -> error {
-                        "Invalid `isReleaseBuild` value '$it' (expected 'true' or 'false')"
-                    }
-                }
-            }
-            ?: false
-
         val metadata = rootDir.resolve("metadata.toml").loadStaticMetadata().let {
-            if (isRelease) it else it.copy(version = it.version.withSuffix("-SNAPSHOT"))
+            if (isReleaseBuild()) it else it.copy(
+                buildDir = it.releaseVersion.toString().withSuffix("-SNAPSHOT"),
+                version = addSnapshotSuffix(it.releaseVersion),
+            )
         }
 
-        logger.lifecycle("${metadata.name} version: ${metadata.version}")
+        logger.lifecycle(buildString {
+            append("${metadata.name} version: ${metadata.releaseVersion}")
+            if (metadata.releaseVersion != metadata.version) append(" (${metadata.version})")
+        })
 
         extensions.add<StaticModMetadata>(EXTENSION_NAME, metadata)
         gradle.settingsEvaluated {
@@ -47,4 +45,46 @@ class ModMetadataPlugin : Plugin<Settings> {
             }
         }
     }
+
+    private fun Settings.isReleaseBuild()
+        = providers.gradleProperty("isReleaseBuild").orNull
+        ?.trim()
+        ?.takeUnless { it.isEmpty() }
+        ?.lowercase()
+        ?.let {
+            when (it) {
+                "true" -> true
+                "false" -> false
+                else -> error("Invalid `isReleaseBuild` value '$it' (expected 'true' or 'false')")
+            }
+        }
+        ?: false
+
+    private fun Settings.addSnapshotSuffix(version: Version) =
+        version.addSnapshotSuffix(GitRepository(rootDir, GradleCommandRunner(providers)))
+
+    internal fun Version.addSnapshotSuffix(repository: GitRepository) = copy(
+        preRelease = buildString {
+            preRelease
+                ?.removeSuffix("-SNAPSHOT")
+                ?.takeUnless { it.isBlank() || it == "SNAPSHOT" }
+                ?.let {
+                    append(it)
+                    append('-')
+                }
+
+            append("SNAPSHOT")
+
+            repository
+                .resolveMetadata()
+                .onFailure { e ->
+                    logger.error("Could not resolve git metadata: ${e.message ?: e.javaClass.name}")
+                }
+                .onSuccess {
+                    append('-')
+                    append(it.revision)
+                    if (it.isDirty) append("-dirty")
+                }
+        },
+    )
 }

--- a/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/StaticModMetadata.kt
+++ b/build-logic/metadata/src/main/kotlin/net/xolt/freecam/model/StaticModMetadata.kt
@@ -3,8 +3,10 @@ package net.xolt.freecam.model
 import dev.eav.tomlkt.Toml
 import dev.eav.tomlkt.TomlNativeReader
 import dev.eav.tomlkt.decodeFromReader
+import io.github.z4kn4fein.semver.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import java.io.File
 
 internal fun File.loadStaticMetadata(): ModMetadataToml {
@@ -24,7 +26,12 @@ internal data class ModMetadataToml(
     override val id: String,
     override val name: String,
     override val group: String,
-    override val version: String,
+    @SerialName("version")
+    override val releaseVersion: Version,
+    @Transient
+    override val version: Version = releaseVersion,
+    @Transient
+    override val buildDir: String = releaseVersion.toString(),
     override val authors: List<String>,
     override val license: String,
     @SerialName("homepage")
@@ -48,6 +55,6 @@ internal data class ModMetadataToml(
 ) : StaticModMetadata {
 
     override val releaseType: ReleaseType by lazy {
-        ReleaseType.fromVersion(version.removeSuffix("-SNAPSHOT"))
+        ReleaseType.fromVersion(releaseVersion.toString())
     }
 }

--- a/build-logic/metadata/src/test/kotlin/net/xolt/freecam/gradle/GitRepositoryTest.kt
+++ b/build-logic/metadata/src/test/kotlin/net/xolt/freecam/gradle/GitRepositoryTest.kt
@@ -1,0 +1,140 @@
+package net.xolt.freecam.gradle
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class GitRepositoryTest {
+
+    private lateinit var rootDir: File
+    private lateinit var cmdRunner: CommandRunner
+    private lateinit var repository: GitRepository
+
+    @BeforeTest
+    fun setup() {
+        cmdRunner = mockk()
+        rootDir = createTempDirectory("git-repo-test").toFile().apply { deleteOnExit() }
+        repository = GitRepository(rootDir, cmdRunner)
+    }
+
+    @Test
+    fun `returns failure when git binary is missing from PATH`() {
+        // CommandRunner returns null when git can't be executed
+        every { cmdRunner(rootDir, "git", "rev-parse", "--show-toplevel") } returns null
+
+        val result = repository.resolveMetadata()
+
+        result.shouldBeFailure {
+            it.message shouldBe "Could not execute git"
+        }
+    }
+
+    @Test
+    fun `returns failure when project directory is not a git repository`() {
+        every { cmdRunner(rootDir, "git", "rev-parse", "--show-toplevel") } returns CommandRunner.Result(
+            exitCode = 128,
+            stdout = null,
+            stderr = "fatal: not a git repository (or any of the parent directories)",
+        )
+
+        val result = repository.resolveMetadata()
+
+        result.shouldBeFailure {
+            it.shouldBeInstanceOf<IllegalStateException>()
+            it.message shouldBe "Not a git repository"
+        }
+    }
+
+    @Test
+    fun `throws IllegalStateException on unexpected git CLI errors`() {
+        every { cmdRunner(rootDir, "git", "rev-parse", "--show-toplevel") } returns CommandRunner.Result(
+            exitCode = 1,
+            stdout = null,
+            stderr = "some internal git explosion",
+        )
+
+        val exception = shouldThrow<IllegalStateException> {
+            repository.resolveMetadata()
+        }
+        exception.message shouldBe "Unknown git error (1): some internal git explosion"
+    }
+
+    @Test
+    fun `returns failure when project is nested inside a different git repository`() {
+        val otherDir = createTempDirectory("different-git-repo").toFile().apply { deleteOnExit() }
+
+        every { cmdRunner(rootDir, "git", "rev-parse", "--show-toplevel") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = otherDir.canonicalPath,
+            stderr = null,
+        )
+
+        val result = repository.resolveMetadata()
+
+        result.shouldBeFailure {
+            it.message shouldBe "Git repo ($otherDir) is not project ($rootDir)."
+        }
+    }
+
+    @Test
+    fun `returns metadata successfully for clean git repository state`() {
+        every { cmdRunner(rootDir, "git", "rev-parse", "--show-toplevel") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = rootDir.canonicalPath,
+            stderr = null,
+        )
+        every { cmdRunner(rootDir, "git", "rev-parse", "--short", "HEAD") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = "b4df00d\n",
+            stderr = "",
+        )
+        every { cmdRunner(rootDir, "git", "status", "--porcelain") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = "",
+            stderr = "",
+        )
+
+        val result = repository.resolveMetadata()
+
+        result.shouldBeSuccess {
+            it.revision shouldBe "b4df00d"
+            it.isDirty.shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `returns metadata successfully and marks dirty flag when modifications exist`() {
+        every { cmdRunner(rootDir, "git", "rev-parse", "--show-toplevel") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = rootDir.canonicalPath,
+            stderr = "",
+        )
+        every { cmdRunner(rootDir, "git", "rev-parse", "--short", "HEAD") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = "a1b2c3d",
+            stderr = "",
+        )
+        every { cmdRunner(rootDir, "git", "status", "--porcelain") } returns CommandRunner.Result(
+            exitCode = 0,
+            stdout = " M src/main/kotlin/Plugin.kt\n?? newfile.txt",
+            stderr = "",
+        )
+
+        val result = repository.resolveMetadata()
+
+        result.shouldBeSuccess {
+            it.revision shouldBe "a1b2c3d"
+            it.isDirty.shouldBeTrue()
+        }
+    }
+}

--- a/build-logic/metadata/src/test/kotlin/net/xolt/freecam/gradle/ModMetadataPluginTest.kt
+++ b/build-logic/metadata/src/test/kotlin/net/xolt/freecam/gradle/ModMetadataPluginTest.kt
@@ -1,0 +1,78 @@
+package net.xolt.freecam.gradle
+
+import io.github.z4kn4fein.semver.Version
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.logging.Logger
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
+import kotlin.test.Test
+
+class ModMetadataPluginTest {
+
+    private val plugin = ModMetadataPlugin()
+
+    @Test
+    fun `addSnapshotSuffix formats stable version cleanly with a healthy git state`() {
+        val repository = mockk<GitRepository> {
+            every { resolveMetadata() } returns success(GitMetadata("b4df00d", isDirty = false))
+        }
+
+        val baseVersion = Version.parse("1.2.0")
+        val result = with(plugin) { baseVersion.addSnapshotSuffix(repository) }
+
+        result.preRelease shouldBe "SNAPSHOT-b4df00d"
+        result.toString() shouldBe "1.2.0-SNAPSHOT-b4df00d"
+    }
+
+    @Test
+    fun `addSnapshotSuffix preserves internal pre-releases and tracks dirty status flags`() {
+        val repository = mockk<GitRepository> {
+            every { resolveMetadata() } returns success(GitMetadata("a1b2c3d", isDirty = true))
+        }
+
+        val baseVersion = Version.parse("2.0.0-rc.3")
+        val result = with(plugin) { baseVersion.addSnapshotSuffix(repository) }
+
+        result.preRelease shouldBe "rc.3-SNAPSHOT-a1b2c3d-dirty"
+        result.toString() shouldBe "2.0.0-rc.3-SNAPSHOT-a1b2c3d-dirty"
+    }
+
+    @Test
+    fun `addSnapshotSuffix drops existing SNAPSHOT tags to avoid duplicates`() {
+        val repository = mockk<GitRepository> {
+            every { resolveMetadata() } returns success(GitMetadata("cafeb0b", isDirty = false))
+        }
+
+        val baseVersion = Version.parse("1.0.0-SNAPSHOT")
+        val result = with(plugin) { baseVersion.addSnapshotSuffix(repository) }
+
+        result.preRelease shouldBe "SNAPSHOT-cafeb0b"
+        result.toString() shouldBe "1.0.0-SNAPSHOT-cafeb0b"
+    }
+
+    @Test
+    fun `addSnapshotSuffix logs error and gracefully falls back to plain SNAPSHOT`() {
+        val repository = mockk<GitRepository> {
+            every { resolveMetadata() } returns failure(IllegalStateException("Could not execute git"))
+        }
+        val logger = mockk<Logger> {
+            every { error(any()) } just Runs
+        }
+        val plugin = ModMetadataPlugin(logger = logger)
+
+        val baseVersion = Version.parse("1.5.1-beta.2")
+        val result = with(plugin) { baseVersion.addSnapshotSuffix(repository) }
+
+        result.preRelease shouldBe "beta.2-SNAPSHOT"
+        result.toString() shouldBe "1.5.1-beta.2-SNAPSHOT"
+
+        verify {
+            logger.error(match { it.startsWith("Could not resolve git metadata: ") })
+        }
+    }
+}

--- a/build-logic/metadata/src/test/kotlin/net/xolt/freecam/model/ModMetadataTomlTest.kt
+++ b/build-logic/metadata/src/test/kotlin/net/xolt/freecam/model/ModMetadataTomlTest.kt
@@ -1,5 +1,6 @@
 package net.xolt.freecam.model
 
+import io.github.z4kn4fein.semver.Version
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -30,11 +31,28 @@ class ModMetadataTomlTest {
         }
     }
 
+    @Test
+    fun `version defaults to releaseVersion upon instantiation`() {
+        val rawVersion = "1.0.0-beta.1"
+        val meta = metadata(rawVersion)
+
+        meta.version shouldBe Version.parse(rawVersion)
+    }
+
+    @Test
+    fun `buildDir defaults to stringified releaseVersion`() {
+        val rawVersion = "1.4.0-rc.2+build.123"
+        val meta = metadata(rawVersion)
+
+        // Ensures buildDir matches the normalized semver string representation
+        meta.buildDir shouldBe Version.parse(rawVersion).toString()
+    }
+
     private fun metadata(version: String) = ModMetadataToml(
         id = "",
         name = "",
         group = "",
-        version = version,
+        releaseVersion = Version.parse(version, strict = false),
         authors = emptyList(),
         license = "",
         homepageUrl = url(),

--- a/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ProjectReleaseMetadataTask.kt
+++ b/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ProjectReleaseMetadataTask.kt
@@ -57,7 +57,7 @@ abstract class ProjectReleaseMetadataTask : DefaultTask() {
         displayName.convention(minecraft.flatMap { mc ->
             loader.flatMap { loader ->
                 meta.map { meta ->
-                    "${meta.version} for MC $mc ($loader)"
+                    "${meta.releaseVersion} for MC $mc ($loader)"
                 }
             }
         })

--- a/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
+++ b/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
@@ -14,7 +14,6 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile

--- a/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
+++ b/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
@@ -61,12 +61,12 @@ abstract class ReleaseMetadataTask : DefaultTask() {
         val meta = project.provider {
             project.extensions.getByType<StaticModMetadata>()
         }
-        version.convention(meta.map { it.version })
+        version.convention(meta.map { it.releaseVersion.toString() })
         releaseType.convention(meta.map { it.releaseType })
-        displayName.convention(meta.map { "${it.name} ${it.version}" })
+        displayName.convention(meta.map { "${it.name} ${it.releaseVersion}" })
         curseforgeId.convention(meta.map { it.curseforgeId.toLong() })
         modrinthId.convention(meta.map { it.modrinthId })
-        githubTag.convention(meta.map { "v${it.version}" })
+        githubTag.convention(meta.map { "v${it.releaseVersion}" })
         changelog.convention("")
         projectMetadataFiles.convention(emptyList())
         outputFile.convention(version.flatMap {

--- a/cloth-config/build.gradle.kts
+++ b/cloth-config/build.gradle.kts
@@ -28,7 +28,7 @@ tasks {
         json {
             modId = "${meta.id}-cloth-config"
             name = "${meta.name} Cloth Config GUI"
-            version = meta.version
+            version = meta.version.toString()
             description = "Provides a ${meta.name} Config GUI when Cloth Config is installed."
             licenses = listOf(meta.license)
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -92,7 +92,7 @@ loom {
 tasks.register<Copy>("buildAndCollect") {
     group = "build"
     from(loomAdapter.modJar.map { it.archiveFile })
-    into(rootProject.layout.buildDirectory.file("libs/${meta.version}"))
+    into(rootProject.layout.buildDirectory.file("libs/${meta.buildDir}"))
     dependsOn(tasks.build)
 }
 
@@ -105,7 +105,7 @@ tasks {
         json {
             modId = meta.id
             name = meta.name
-            version = meta.version
+            version = meta.version.toString()
             description = meta.description
             licenses = listOf(meta.license)
             meta.authors.forEach(::author)

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -131,7 +131,7 @@ sourceSets.main {
 tasks.register<Copy>("buildAndCollect") {
     group = "build"
     from(tasks.named<Jar>("reobfJar").map { it.archiveFile })
-    into(rootProject.layout.buildDirectory.file("libs/${meta.version}"))
+    into(rootProject.layout.buildDirectory.file("libs/${meta.buildDir}"))
     dependsOn("build")
 }
 

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -70,7 +70,7 @@ sourceSets.main {
 tasks.register<Copy>("buildAndCollect") {
     group = "build"
     from(tasks.jar.map { it.archiveFile })
-    into(rootProject.layout.buildDirectory.file("libs/${meta.version}"))
+    into(rootProject.layout.buildDirectory.file("libs/${meta.buildDir}"))
     dependsOn(tasks.build)
 }
 


### PR DESCRIPTION

If git is installed and the project is a git repo, append `git rev-parse --short HEAD` and whether the worktree is dirty or not to the `-SNAPSHOT` version.
