### PR TITLE
build(forge): use shadow to bundle dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Changed
 
+- Cloth Config is now bundled on all builds ([539](https://github.com/MinecraftFreecam/Freecam/pull/539))
+  - Previously, Cloth Config needed to be installed separately on MC 1.17.1 Forge builds
+
 ### Removed
 
 - Dropped dependency on Fabric API ([537](https://github.com/MinecraftFreecam/Freecam/pull/537))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 ### Fixed
 
 - Resolved Fabric Loader "invalid version" warnings related to our Cloth Config implementation ([486](https://github.com/MinecraftFreecam/Freecam/issues/486), [534](https://github.com/MinecraftFreecam/Freecam/pull/534))
+- Fixed our Config GUI not being available for (legacy) Forge builds ([539](https://github.com/MinecraftFreecam/Freecam/pull/539))
 
 ## [1.4.1-beta.1] - 2026-06-26
 

--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/FmlModsToml.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/FmlModsToml.kt
@@ -15,6 +15,11 @@ data class FmlModsToml(
     val license: String,
     val issueTrackerURL: String? = null,
 
+    /** Default for [FmlModEntry.logoFile] */
+    val logoFile: String? = null,
+    /** Default for [FmlModEntry.logoBlur] */
+    val logoBlur: Boolean? = null,
+
     val mods: List<FmlModEntry> = emptyList(),
     val dependencies: Map<String, List<FmlDependencyEntry>>? = null,
 
@@ -87,3 +92,24 @@ data class FmlMixinEntry(
  */
 @Serializable
 data class FmlAccessTransformerEntry(val file: String)
+
+
+/**
+ * Push top-level defaults down to individual [mods].
+ */
+fun FmlModsToml.pushDownDefaults(): FmlModsToml {
+    val defaultLogoFile = logoFile
+    val defaultLogoBlur = logoBlur
+    if (defaultLogoFile == null && defaultLogoBlur == null) return this
+
+    return copy(
+        logoFile = null,
+        logoBlur = null,
+        mods = mods.map { mod ->
+            mod.copy(
+                logoFile = mod.logoFile ?: defaultLogoFile,
+                logoBlur = mod.logoBlur ?: defaultLogoBlur,
+            )
+        },
+    )
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -40,6 +40,7 @@ include(
     "loom-adapter",
     "fml-support",
     "metadata",
+    "shadow",
     "release-metadata",
     "settings",
 )

--- a/build-logic/shadow/build.gradle.kts
+++ b/build-logic/shadow/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `kotlin-dsl`
+    `java-gradle-plugin`
+}
+
+dependencies {
+    implementation(project(":api"))
+    implementation(libs.plugins.shadow.coords)
+    implementation(libs.kotlin.serialization.toml)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotest.assertions)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/build-logic/shadow/src/main/kotlin/freecam.shadow.gradle.kts
+++ b/build-logic/shadow/src/main/kotlin/freecam.shadow.gradle.kts
@@ -1,0 +1,10 @@
+/**
+ * Applying this plugin to a project will transitively pull in its classpath,
+ * giving the project access to `:build-logic:shadow` classes.
+ *
+ * It also applies the GradleUp `shadow` plugin, for convenience.
+ */
+
+plugins {
+    id("com.gradleup.shadow")
+}

--- a/build-logic/shadow/src/main/kotlin/net/xolt/freecam/model/FmlModsTomlExtensions.kt
+++ b/build-logic/shadow/src/main/kotlin/net/xolt/freecam/model/FmlModsTomlExtensions.kt
@@ -1,0 +1,49 @@
+package net.xolt.freecam.model
+
+/**
+ * Merge nested data from two [FmlModsToml]s.
+ *
+ * Top-level fields from this [FmlModsToml] are kept as-is, while "nested" fields are merged:
+ * - [mods]
+ * - [dependencies]
+ * - [mixins]
+ * - [accessTransformers]
+ *
+ * Top-level defaults (like [logoFile]) are pushed down using [pushDownDefaults] to preserve semantics.
+ */
+internal infix fun FmlModsToml.mergeWith(incoming: FmlModsToml): FmlModsToml {
+    val self = this.pushDownDefaults()
+    val other = incoming.pushDownDefaults()
+    return self.copy(
+        mods = self.mods + other.mods,
+        dependencies = mergeDependencies(self.dependencies, other.dependencies),
+        mixins = mergeLists(self.mixins, other.mixins),
+        accessTransformers = mergeLists(self.accessTransformers, other.accessTransformers),
+    )
+}
+
+/**
+ * Merges nullable dependency maps.
+ * Combines keys and concatenates matching mod ID lists.
+ */
+private fun mergeDependencies(
+    base: Map<String, List<FmlDependencyEntry>>?,
+    incoming: Map<String, List<FmlDependencyEntry>>?
+): Map<String, List<FmlDependencyEntry>>? {
+    if (base == null && incoming == null) return null
+    if (base == null) return incoming
+    if (incoming == null) return base
+
+    val allKeys = base.keys + incoming.keys
+    return allKeys.associateWith { modId ->
+        (base[modId] ?: emptyList()) + (incoming[modId] ?: emptyList())
+    }
+}
+
+/**
+ * Merges nullable lists.
+ */
+private fun <T> mergeLists(base: List<T>?, incoming: List<T>?): List<T>? {
+    if (base == null && incoming == null) return null
+    return (base ?: emptyList()) + (incoming ?: emptyList())
+}

--- a/build-logic/shadow/src/main/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTask.kt
+++ b/build-logic/shadow/src/main/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTask.kt
@@ -1,0 +1,62 @@
+package net.xolt.freecam.shadow.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.*
+import java.io.File
+import javax.inject.Inject
+
+@CacheableTask
+abstract class NormalizeShadowBundleTask @Inject constructor(
+    private val fs: FileSystemOperations,
+    private val archives: ArchiveOperations,
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val inputFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    val outputDir = objects.directoryProperty().convention(project.layout.buildDirectory.dir("shadow-bundle"))
+
+    @get:Internal
+    val outputFiles = objects.fileCollection().from(
+        inputFiles.elements.zip(outputDir) { files, rootDir ->
+            files.map { rootDir.dir(it.asFile.nameWithoutExtension) }
+        }
+    )
+
+    @TaskAction
+    fun process() {
+        val dest = outputDir.get().asFile.apply {
+            deleteRecursively()
+        }
+
+        inputFiles.files.forEach { file ->
+            file processInto dest.resolve(file.nameWithoutExtension)
+        }
+    }
+
+    internal infix fun File.processInto(dest: File) {
+        val inputFile = this
+        val inputName = nameWithoutExtension.namePrefix
+
+        fs.sync {
+            from(archives.zipTree(inputFile))
+            into(dest)
+        }
+    }
+}
+
+/**
+ * Get the name prefix of a jar file, stopping at the version number.
+ * For example, `"cloth-config-5.3.63"` would return `"cloth-config"`.
+ */
+internal val String.namePrefix: String
+    get() = split('-')
+        .takeWhile { it.firstOrNull()?.isLetter() ?: true }
+        .joinToString("-")

--- a/build-logic/shadow/src/main/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTask.kt
+++ b/build-logic/shadow/src/main/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTask.kt
@@ -1,13 +1,20 @@
 package net.xolt.freecam.shadow.tasks
 
+import dev.eav.tomlkt.*
+import net.xolt.freecam.model.FmlModsToml
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.logging.Logging
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.*
 import java.io.File
 import javax.inject.Inject
+import kotlin.io.path.Path
+
+private val serializer = Toml { explicitNulls = false }
+private val logger = Logging.getLogger(NormalizeShadowBundleTask::class.java)
 
 @CacheableTask
 abstract class NormalizeShadowBundleTask @Inject constructor(
@@ -45,11 +52,63 @@ abstract class NormalizeShadowBundleTask @Inject constructor(
         val inputFile = this
         val inputName = nameWithoutExtension.namePrefix
 
+        val renamedIcons = mutableListOf<String>()
+
         fs.sync {
             from(archives.zipTree(inputFile))
             into(dest)
+
+            filesMatching("icon.png") {
+                renamedIcons += relativePath.pathString
+                name = "$inputName-$name"
+            }
+        }
+
+        dest.resolve("META-INF/mods.toml").takeIf(File::exists)?.let { file ->
+            val modsToml = file
+                .bufferedReader().use { reader ->
+                    serializer.decodeFromNativeReader<TomlTable>(reader)
+                }
+                .normalizeModsToml { key, value ->
+                    logger.error("$inputName: invalid top-level ${file.name} key '$key' with value '$value'")
+                }
+                .asFmlModsToml()
+                .prefixLogoFiles(inputName, renamedIcons)
+
+            file.bufferedWriter().use { writer ->
+                serializer.encodeToNativeWriter(modsToml, writer)
+            }
         }
     }
+}
+
+private fun TomlTable.asFmlModsToml() =
+    serializer.decodeFromTomlElement<FmlModsToml>(this)
+
+internal fun FmlModsToml.prefixLogoFiles(prefix: String, logoPaths: Iterable<String>) =
+    logoPaths.fold(this) { acc, logo -> acc.prefixLogoFile(prefix, logo) }
+
+internal fun TomlTable.normalizeModsToml(onInvalid: (String, TomlElement) -> Unit = { _, _ -> }) = TomlTable(
+    toMutableMap().apply {
+        // Cloth Config incorrectly defines some mod-level fields at the top-level
+        sequenceOf("authors", "displayURL").forEach { key ->
+            remove(key)?.also { onInvalid(key, it) }
+        }
+    }
+)
+
+internal fun FmlModsToml.prefixLogoFile(prefix: String, logo: String): FmlModsToml {
+    fun String.prefixed() =
+        if (this == logo) Path(this).let {
+            it.resolveSibling("$prefix-${it.fileName}")
+        }.toString()
+        else this
+    return copy(
+        logoFile = logoFile?.prefixed(),
+        mods = mods.map { mod ->
+            mod.copy(logoFile = mod.logoFile?.prefixed())
+        },
+    )
 }
 
 /**

--- a/build-logic/shadow/src/main/kotlin/net/xolt/freecam/shadow/transformers/ModsTomlTransformer.kt
+++ b/build-logic/shadow/src/main/kotlin/net/xolt/freecam/shadow/transformers/ModsTomlTransformer.kt
@@ -1,0 +1,63 @@
+package net.xolt.freecam.shadow.transformers
+
+import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import dev.eav.tomlkt.Toml
+import dev.eav.tomlkt.decodeFromNativeReader
+import kotlinx.serialization.encodeToString
+import net.xolt.freecam.model.FmlModsToml
+import net.xolt.freecam.model.mergeWith
+import org.apache.tools.zip.ZipEntry
+import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
+private val serializer = Toml {
+    explicitNulls = false
+}
+
+@CacheableTransformer
+class ModsTomlTransformer : ResourceTransformer {
+
+    @get:Input
+    var path: String = "META-INF/mods.toml"
+
+    @get:Internal
+    internal var mergedData: FmlModsToml? = null
+    private var lastModified: Long? = null
+
+    override fun canTransformResource(element: FileTreeElement): Boolean {
+        val isMatch = path == element.relativePath.pathString
+        // The first match should be the canonical file, so capture its timestamp
+        if (isMatch && lastModified == null) lastModified = element.lastModified
+        return isMatch
+    }
+
+    override fun hasTransformedResource(): Boolean = mergedData != null
+
+    override fun transform(context: TransformerContext) {
+        val incomingToml: FmlModsToml = context.inputStream.use { stream ->
+            serializer.decodeFromNativeReader(stream.bufferedReader())
+        }
+
+        mergedData = mergedData?.mergeWith(incomingToml) ?: incomingToml
+    }
+
+    override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
+        val data = mergedData ?: return
+
+        val entry = ZipEntry(path).apply {
+            if (preserveFileTimestamps) {
+                lastModified?.let { time = it }
+            }
+        }
+
+        val content = serializer.encodeToString(data)
+
+        os.putNextEntry(entry)
+        os.write(content.toByteArray(Charsets.UTF_8))
+        os.closeEntry()
+    }
+}

--- a/build-logic/shadow/src/test/kotlin/net/xolt/freecam/model/FmlModsTomlMergeTest.kt
+++ b/build-logic/shadow/src/test/kotlin/net/xolt/freecam/model/FmlModsTomlMergeTest.kt
@@ -1,0 +1,83 @@
+package net.xolt.freecam.model
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class FmlModsTomlMergeTest {
+
+    private val baseToml = FmlModsToml(
+        modLoader = "javafml",
+        loaderVersion = "40",
+        license = "MIT",
+    )
+
+    @Test
+    fun `mergeWith takes top-level fields exclusively from base`() {
+        val mods = listOf(FmlModEntry(modId = "freecam", version = "1.0", displayName = "Freecam"))
+        val canonical = baseToml
+        val incoming = FmlModsToml(
+            modLoader = "lowcodefml",
+            loaderVersion = "69",
+            license = "GPL",
+            mods = mods,
+        )
+
+        val result = canonical mergeWith incoming
+
+        result shouldBe baseToml.copy(mods = mods)
+    }
+
+    @Test
+    fun `mergeWith appends arrays in correct sequential order`() {
+        val canonical = baseToml.copy(
+            mods = listOf(FmlModEntry(modId = "freecam", version = "1.0", displayName = "Freecam")),
+        )
+        val incoming = baseToml.copy(
+            mods = listOf(FmlModEntry(modId = "cloth-config", version = "2.0", displayName = "Cloth Config")),
+        )
+
+        val result = canonical.mergeWith(incoming)
+
+        result.mods.map { it.modId } shouldBe listOf("freecam", "cloth-config")
+    }
+
+    @Test
+    fun `mergeWith safely merges disjoint dependency maps without dropping keys`() {
+        val canonical = baseToml.copy(
+            dependencies = mapOf(
+                "freecam" to listOf(FmlDependencyEntry(modId = "foo", versionRange = "40")),
+            )
+        )
+        val incoming = baseToml.copy(
+            dependencies = mapOf(
+                "cloth-config" to listOf(FmlDependencyEntry(modId = "bar", versionRange = "1.0")),
+            )
+        )
+
+        val result = canonical.mergeWith(incoming)
+
+        val deps = result.dependencies
+        deps?.keys shouldBe setOf("freecam", "cloth-config")
+        deps?.get("freecam")?.map { it.modId } shouldBe listOf("foo")
+        deps?.get("cloth-config")?.map { it.modId } shouldBe listOf("bar")
+    }
+
+    @Test
+    fun `mergeWith concatenates dependency lists when maps share the same modId key`() {
+        val canonical = baseToml.copy(
+            dependencies = mapOf(
+                "freecam" to listOf(FmlDependencyEntry(modId = "forge", versionRange = "40")),
+            )
+        )
+        val incoming = baseToml.copy(
+            dependencies = mapOf(
+                "freecam" to listOf(FmlDependencyEntry(modId = "minecraft", versionRange = "1.20")),
+            )
+        )
+
+        val result = canonical.mergeWith(incoming)
+
+        val freecamDeps = result.dependencies?.get("freecam")
+        freecamDeps?.map { it.modId } shouldBe listOf("forge", "minecraft")
+    }
+}

--- a/build-logic/shadow/src/test/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTaskTest.kt
+++ b/build-logic/shadow/src/test/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTaskTest.kt
@@ -1,7 +1,12 @@
 package net.xolt.freecam.shadow.tasks
 
+import dev.eav.tomlkt.TomlLiteral
+import dev.eav.tomlkt.TomlTable
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.shouldBe
+import net.xolt.freecam.model.FmlModEntry
+import net.xolt.freecam.model.FmlModsToml
 import org.junit.jupiter.api.Test
 
 class NormalizeShadowBundleTaskTest {
@@ -17,5 +22,149 @@ class NormalizeShadowBundleTaskTest {
         withClue("No version or segments") {
             "freecam".namePrefix shouldBe "freecam"
         }
+    }
+
+    @Test
+    fun `normalizeModsToml removes legacy invalid root fields`() {
+        val input = TomlTable(
+            "modLoader" to TomlLiteral("javafml"),
+            "authors" to TomlLiteral("shedaniel"),
+            "displayURL" to TomlLiteral("example.com"),
+            "logoFile" to TomlLiteral("icon.png"),
+        )
+
+        val result = input.normalizeModsToml()
+
+        result.keys shouldBe setOf(
+            "modLoader",
+            "logoFile",
+        )
+    }
+
+    @Test
+    fun `normalizeModsToml reports removed keys`() {
+        val removed = mutableListOf<Pair<String, String>>()
+
+        TomlTable(
+            "authors" to TomlLiteral("foobar"),
+            "displayURL" to TomlLiteral("example.com"),
+        ).normalizeModsToml { key, value ->
+            removed += key to value.toString()
+        }
+
+        removed shouldBe listOf(
+            "authors" to "foobar",
+            "displayURL" to "example.com",
+        )
+    }
+
+    @Test
+    fun `prefixLogoFile renames matching logo paths`() {
+        val input = FmlModsToml(
+            modLoader = "javafml",
+            loaderVersion = "40",
+            license = "MIT",
+            logoFile = "assets/icon.png",
+            mods = listOf(
+                FmlModEntry(
+                    modId = "cloth",
+                    version = "1",
+                    displayName = "Cloth",
+                    logoFile = "assets/icon.png",
+                )
+            )
+        )
+
+        val result = input.prefixLogoFile("cloth-config", "assets/icon.png")
+
+        result.logoFile shouldBe "assets/cloth-config-icon.png"
+        result.mods.shouldBeSingleton { mod ->
+            mod.logoFile shouldBe "assets/cloth-config-icon.png"
+        }
+    }
+
+    @Test
+    fun `prefixLogoFile ignores non-matching logo paths`() {
+        val input = FmlModsToml(
+            modLoader = "javafml",
+            loaderVersion = "40",
+            license = "MIT",
+            logoFile = "assets/logo.png",
+            mods = listOf(
+                FmlModEntry(
+                    modId = "cloth",
+                    version = "1",
+                    displayName = "Cloth",
+                    logoFile = "assets/logo.png",
+                )
+            )
+        )
+
+        val result = input.prefixLogoFile("cloth-config", "assets/icon.png")
+
+        result.logoFile shouldBe "assets/logo.png"
+        result.mods.shouldBeSingleton { mod ->
+            mod.logoFile shouldBe "assets/logo.png"
+        }
+    }
+
+    @Test
+    fun `prefixLogoFiles renames matching logos`() {
+        val input = FmlModsToml(
+            modLoader = "javafml",
+            loaderVersion = "[1,)",
+            license = "MIT",
+            mods = listOf(
+                FmlModEntry(
+                    modId = "a",
+                    version = "1.0.0",
+                    displayName = "A",
+                    logoFile = "assets/icon.png",
+                ),
+                FmlModEntry(
+                    modId = "b",
+                    version = "1.0.0",
+                    displayName = "B",
+                    logoFile = "assets/logo.png",
+                ),
+                FmlModEntry(
+                    modId = "c",
+                    version = "1.0.0",
+                    displayName = "C",
+                    logoFile = "other-icon.png",
+                ),
+            )
+        )
+
+        val result = input.prefixLogoFiles(
+            prefix = "pfx",
+            logoPaths = listOf(
+                "assets/icon.png",
+                "other-icon.png",
+            )
+        )
+
+        result shouldBe result.copy(
+            mods = listOf(
+                FmlModEntry(
+                    modId = "a",
+                    version = "1.0.0",
+                    displayName = "A",
+                    logoFile = "assets/pfx-icon.png",
+                ),
+                FmlModEntry(
+                    modId = "b",
+                    version = "1.0.0",
+                    displayName = "B",
+                    logoFile = "assets/logo.png",
+                ),
+                FmlModEntry(
+                    modId = "c",
+                    version = "1.0.0",
+                    displayName = "C",
+                    logoFile = "pfx-other-icon.png",
+                ),
+            )
+        )
     }
 }

--- a/build-logic/shadow/src/test/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTaskTest.kt
+++ b/build-logic/shadow/src/test/kotlin/net/xolt/freecam/shadow/tasks/NormalizeShadowBundleTaskTest.kt
@@ -1,0 +1,21 @@
+package net.xolt.freecam.shadow.tasks
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class NormalizeShadowBundleTaskTest {
+
+    @Test
+    fun `namePrefix extracts mod name by dropping numeric semantic version suffixes`() {
+        "cloth-config-5.3.63".namePrefix shouldBe "cloth-config"
+        "cloth-config-forge-5.3.63".namePrefix shouldBe "cloth-config-forge"
+        "jei-1.17.1-8.3.0.0".namePrefix shouldBe "jei"
+        "foo-v2-1.11".namePrefix shouldBe "foo-v2"
+        "".namePrefix shouldBe ""
+
+        withClue("No version or segments") {
+            "freecam".namePrefix shouldBe "freecam"
+        }
+    }
+}

--- a/build-logic/shadow/src/test/kotlin/net/xolt/freecam/shadow/transformers/ModsTomlTransformerTest.kt
+++ b/build-logic/shadow/src/test/kotlin/net/xolt/freecam/shadow/transformers/ModsTomlTransformerTest.kt
@@ -1,0 +1,61 @@
+package net.xolt.freecam.shadow.transformers
+
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.io.ByteArrayInputStream
+import kotlin.test.Test
+
+class ModsTomlTransformerTest {
+
+    private fun createContext(content: String): TransformerContext {
+        return TransformerContext(
+            path = "META-INF/mods.toml",
+            inputStream = ByteArrayInputStream(content.toByteArray(Charsets.UTF_8)),
+            relocators = emptySet(),
+        )
+    }
+
+    @Test
+    fun `first file processed is treated as canonical and retains root properties`() {
+        val transformer = ModsTomlTransformer()
+        val canonical = """
+            modLoader = "javafml"
+            loaderVersion = "[40,)"
+            license = "MIT"
+            [[mods]]
+            modId = "freecam"
+            version = "1.0.0"
+            displayName = "Freecam"
+        """.trimIndent()
+
+        transformer.transform(createContext(canonical))
+
+        val secondary = """
+            modLoader = "wrongLoader"
+            loaderVersion = "wrongVersion"
+            license = "wrongLicense"
+            [[mods]]
+            modId = "cloth-config"
+            version = "5.3.63"
+            displayName = "Cloth Config"
+        """.trimIndent()
+
+        transformer.transform(createContext(secondary))
+
+        val merged = transformer.mergedData
+
+        merged.shouldNotBeNull()
+
+        withClue("top-level primitives come from canonical TOML") {
+            merged.modLoader shouldBe "javafml"
+            merged.loaderVersion shouldBe "[40,)"
+            merged.license shouldBe "MIT"
+        }
+
+        withClue("nested arrays are merged") {
+            merged.mods.map { it.modId } shouldBe listOf("freecam", "cloth-config")
+        }
+    }
+}

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,15 +1,20 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoundResourceTransformer
 import io.github.z4kn4fein.semver.constraints.toMavenFormat
 import kotlinx.serialization.json.*
 import net.neoforged.moddevgradle.legacyforge.internal.MinecraftMappings
 import net.xolt.freecam.gradle.ForgeModsTomlTask
+import net.xolt.freecam.shadow.tasks.NormalizeShadowBundleTask
+import net.xolt.freecam.shadow.transformers.ModsTomlTransformer
 
 plugins {
     alias(libs.plugins.moddev.legacy)
     alias(libs.plugins.fletchingtable)
-    alias(libs.plugins.shadow)
     id("freecam.loaders")
     id("freecam.atremapper")
     id("freecam.fml")
+    id("freecam.shadow")
 }
 
 val json = Json { prettyPrint = true }
@@ -63,6 +68,7 @@ legacyForge {
 val bundle by configurations.creating {
     isCanBeResolved = true
     isCanBeConsumed = false
+    isTransitive = false
 
     attributes {
         attribute(MinecraftMappings.ATTRIBUTE, objects.named(MinecraftMappings.NAMED))
@@ -70,13 +76,23 @@ val bundle by configurations.creating {
 }
 
 /**
- * Wrapper for [jarJar], only applied on Forge versions that support jar-in-jar.
+ * Wrapper for [jarJar] and [bundle].
  *
- * Jar-in-jar added in [Forge 40.1.60](https://maven.minecraftforge.net/net/minecraftforge/forge/1.18.2-40.1.60/forge-1.18.2-40.1.60-changelog.txt)
+ * You **must** also [`relocate`](https://gradleup.com/shadow/configuration/relocation) third-party packages in `tasks.shadowJar`,
+ * to avoid namespace conflicts on Forge versions without Jar-in-Jar support.
+ *
+ * Jar-in-jar was added in [Forge 40.1.60](https://maven.minecraftforge.net/net/minecraftforge/forge/1.18.2-40.1.60/forge-1.18.2-40.1.60-changelog.txt)
+ *
+ * @param dependencyNotation the dependency to bundle
+ * @param shadowJarConfig configuration for the `shadowJar` task, applied when Jar-in-Jar is not available
  */
-fun DependencyHandler.include(dependency: Any) {
-    if (sc.eval(forgeVersion, "<40.1.60")) return
-    jarJar(dependency)
+fun DependencyHandler.include(dependencyNotation: Any, shadowJarConfig: ShadowJar.() -> Unit) {
+    if (sc.eval(forgeVersion, ">=40.1.60")) {
+        jarJar(dependencyNotation)
+    } else {
+        add(bundle.name, dependencyNotation)
+        tasks.shadowJar { shadowJarConfig() }
+    }
 }
 
 dependencies {
@@ -94,12 +110,22 @@ dependencies {
         // `jarJar` requires a SRG dependency, which we don't have for `:cloth-config`.
         // Instead, we can include named-classes in jar and reobfJar will remap them.
         bundle(implementation(project(path = it.project.path, configuration = "namedElements"))!!)
-        include(modImplementation("me.shedaniel.cloth:cloth-config-forge") {
+        val clothConfigForge = modImplementation("me.shedaniel.cloth:cloth-config-forge") {
             version {
                 prefer(clothVersion)
                 strictly(clothConstraint.toMavenFormat())
             }
-        })
+        }
+        include(clothConfigForge) {
+            sequenceOf(
+                "me.shedaniel.cloth",
+                "me.shedaniel.autoconfig",
+                "me.shedaniel.clothconfig2",
+                "me.shedaniel.math",
+            ).forEach { pattern ->
+                relocate(pattern, "${meta.group}.shadowed.$pattern")
+            }
+        }
     } ?: logger.warn("No :cloth-config project for ${project.path}")
 }
 
@@ -219,16 +245,45 @@ tasks.jar {
     finalizedBy("reobfJar")
 }
 
+val normalizeShadowBundleTask = tasks.register<NormalizeShadowBundleTask>("normalizeShadowBundle") {
+    description = "Normalize dependencies before bundling with Shadow"
+    inputFiles.from(bundle)
+}
+
 tasks.shadowJar {
     duplicatesStrategy = DuplicatesStrategy.FAIL
     failOnDuplicateEntries = true
     archiveClassifier = null
 
-    configurations = setOf(bundle)
+    // Don't use the `shadow` configuration
+    configurations = emptySet()
+    from(normalizeShadowBundleTask.map { it.outputFiles })
     from(mixinRefmap)
     from(tasks.jarJar)
 
     exclude("fabric.mod.json")
+
+    filesMatching("META-INF/mods.toml") {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+    transform<ModsTomlTransformer> {
+        path = "META-INF/mods.toml"
+    }
+
+    filesMatching("META-INF/accesstransformer.cfg") {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+    transform<AppendingTransformer> {
+        resource = "META-INF/accesstransformer.cfg"
+        separator = "\n\n"
+    }
+
+    filesMatching("pack.mcmeta") {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+    transform<PreserveFirstFoundResourceTransformer> {
+        include("pack.mcmeta")
+    }
 
     finalizedBy("reobfShadowJar")
 }

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -6,6 +6,7 @@ import net.xolt.freecam.gradle.ForgeModsTomlTask
 plugins {
     alias(libs.plugins.moddev.legacy)
     alias(libs.plugins.fletchingtable)
+    alias(libs.plugins.shadow)
     id("freecam.loaders")
     id("freecam.atremapper")
     id("freecam.fml")
@@ -53,8 +54,12 @@ legacyForge {
     }
 }
 
-// Include bundled dependencies in `jar`.
-// Not suitable for third-party libs — consider using the gradleup shadow plugin.
+/**
+ * Include a dependency in the `shadowJar` task.
+ * For third-party libraries, use [include] instead to take advantage of Forge's JarJar system.
+ *
+ * We avoid using the default `shadow` configuration, because it is pre-configured to inherit from other configurations.
+ */
 val bundle by configurations.creating {
     isCanBeResolved = true
     isCanBeConsumed = false
@@ -121,10 +126,8 @@ legacyForge {
     }
 }
 
-mixin {
-    add(sourceSets.main.get(), refmapName)
-    mixinConfigNames.forEach(::config)
-}
+val mixinRefmap: Provider<RegularFile> = mixin.add(sourceSets.main.get(), refmapName)
+mixinConfigNames.forEach(mixin::config)
 
 sourceSets.main {
     resources.srcDir("src/generated/resources")
@@ -132,9 +135,13 @@ sourceSets.main {
 
 tasks.register<Copy>("buildAndCollect") {
     group = "build"
-    from(tasks.named<Jar>("reobfJar").map { it.archiveFile })
+    from(tasks.named<Jar>("reobfShadowJar").map { it.archiveFile })
     into(rootProject.layout.buildDirectory.file("libs/${meta.buildDir}"))
     dependsOn("build")
+}
+
+tasks.generateReleaseMetadata {
+    artifactFileName = tasks.named<Jar>("reobfShadowJar").flatMap { it.archiveFileName }
 }
 
 val generateModsTomlTask = tasks.register<ForgeModsTomlTask>("generateModsToml") {
@@ -203,21 +210,40 @@ tasks.processResources {
 }
 
 tasks.jar {
-    from(provider { bundle.map(::zipTree) }) {
-        exclude(
-            "${meta.id}.LICENSE",
-            "META-INF/mods.toml",
-            "META-INF/*.MF",
-            "META-INF/*.SF",
-            "META-INF/*.DSA",
-            "META-INF/*.RSA",
-        )
-    }
+    archiveClassifier = "minimal"
 
     manifest.attributes(
         "MixinConfigs" to mixinConfigNames.joinToString(","),
     )
 
-    duplicatesStrategy = DuplicatesStrategy.FAIL
     finalizedBy("reobfJar")
+}
+
+tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    failOnDuplicateEntries = true
+    archiveClassifier = null
+
+    configurations = setOf(bundle)
+    from(mixinRefmap)
+    from(tasks.jarJar)
+
+    exclude("fabric.mod.json")
+
+    finalizedBy("reobfShadowJar")
+}
+
+obfuscation {
+    reobfuscate(tasks.shadowJar, sourceSets.main.get())
+}
+
+configurations {
+    apiElements {
+        outgoing.artifacts.clear()
+        outgoing.artifact(tasks.shadowJar)
+    }
+    runtimeElements {
+        outgoing.artifacts.clear()
+        outgoing.artifact(tasks.shadowJar)
+    }
 }

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlin = "2.3.0"
+shadow = "9.5.1"
 freecam-publisher = "v0.0.2"
 stonecutter = "0.9.3"
 fabric-loom = "1.17-SNAPSHOT"
@@ -33,6 +34,7 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 stonecutter = { id = "dev.kikugie.stonecutter", version.ref = "stonecutter" }
 fabric-loom = { id = "net.fabricmc.fabric-loom", version.ref = "fabric-loom" }
 fabric-loom-remap = { id = "net.fabricmc.fabric-loom-remap", version.ref = "fabric-loom" }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("freecam.api")
     id("freecam.release-metadata")
     id("dev.kikugie.stonecutter")
-    alias(libs.plugins.shadow) apply false
+    id("freecam.shadow") apply false
 }
 
 stonecutter active "26.2"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("freecam.api")
     id("freecam.release-metadata")
     id("dev.kikugie.stonecutter")
+    alias(libs.plugins.shadow) apply false
 }
 
 stonecutter active "26.2"

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -137,8 +137,6 @@ fabric.supported_mc_versions = ["1.17"]
 fabric.reqs.mc = "~1.17"
 forge.reqs.mc = "~1.17.1"
 
-forge.relationship.cloth-config.type = "optional"
-
 
 ["1.16.5"]
 supported_mc_versions = ["1.16.2", "1.16.3", "1.16.4"]
@@ -153,5 +151,3 @@ reqs.fabric_loader = ">=0.12.11"
 deps.forge_version = "36.2.41"
 reqs.forge_version = ">=34"
 reqs.forge_loader = ">=34"
-
-forge.relationship.cloth-config.type = "optional"


### PR DESCRIPTION
Part one: use shadow to bundle our internals, instead of manual ZipTree processing.

Part two: use shadow when jar-in-jar is unavailable; this is more involved as we need to handle Forge metadata (`mods.toml`, Access Transformers, logo file conflicts, ...)