### PR TITLE
fix(forge): show correct Cloth Config license when shadowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Fixed
 
+- Show the correct Cloth Config license in the Forge 1.17.1 build ([549](https://github.com/MinecraftFreecam/Freecam/pull/549))
+
 ## [1.4.1-beta.2] - 2026-07-13
 
 1.4.1 adds initial support for Minecraft 26.2 and a new 'Outline Player' feature.

--- a/forge/src/main/java/net/xolt/freecam/forge/mixins/ModListScreenMixin.java
+++ b/forge/src/main/java/net/xolt/freecam/forge/mixins/ModListScreenMixin.java
@@ -1,0 +1,51 @@
+package net.xolt.freecam.forge.mixins;
+
+//~ if >=1.18 'fmlclient.gui.screen' -> 'client.gui'
+import net.minecraftforge.client.gui.ModListScreen;
+//~ if >=1.18 fmlclient -> client
+import net.minecraftforge.client.gui.widget.ModListWidget;
+//? if forge: >=41.1
+import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
+
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.forgespi.language.IModFileInfo;
+import net.xolt.freecam.Freecam;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Map;
+
+@Mixin(ModListScreen.class)
+abstract class ModListScreenMixin {
+
+    // When shadowing third-party mods, we merge them into our `mods.toml` file.
+    // Unfortunately, FML only allows defining `license` per-file instead of per-mod.
+    @Unique
+    private static final Map<String, String> freecam$LICENSE_OVERRIDES = Map.of(
+        "cloth_config", "GNU LGPLv3"
+    );
+
+    @Shadow(remap = false)
+    private ModListWidget.ModEntry selected;
+
+    //~ if forge: >=41.1 'forgespi/language/IModFileInfo' -> 'fml/loading/moddiscovery/ModFileInfo'
+    @Redirect(method = "updateCache", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/loading/moddiscovery/ModFileInfo;getLicense()Ljava/lang/String;"), remap = false)
+    //~ if forge: >=41.1 IModFileInfo -> ModFileInfo
+    String onGetLicense(ModFileInfo info) {
+        // When using Freecam's ModFileInfo, check if we need to override the selected mod's license
+        if (info == freecam$getOurModFileInfo()) {
+            String override = freecam$LICENSE_OVERRIDES.get(selected.getInfo().getModId());
+            if (override != null) return override;
+        }
+
+        return info.getLicense();
+    }
+
+    @Unique
+    private IModFileInfo freecam$getOurModFileInfo() {
+        return ModList.get().getModFileById(Freecam.MOD_ID);
+    }
+}

--- a/forge/src/main/resources/freecam-forge.mixins.json
+++ b/forge/src/main/resources/freecam-forge.mixins.json
@@ -5,7 +5,8 @@
   "compatibilityLevel": "${mixinCompatLevel}",
   "minVersion": "0.8",
   "client": [
-    "EntityRenderDispatcherMixin"
+    "EntityRenderDispatcherMixin",
+    "ModListScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Merging FML `mods.toml` files in the shadowJar task does not preserve per-mod `license` information, as FML only allows defining the license per-file rather than per-mod.

This introduces `ModListScreenMixin` to manually override the correct GNU LGPLv3 license for Cloth Config when viewed in Forge's mods screen.

Overrides are only applied when `getLicense()` is called on _Freecam's_ instance of `IModFileInfo`, so this does not affect other mods or non-shadow (Jar-in-Jar) mods.
