### PR TITLE
ci: optimize Gradle configuration & execution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Run gradle
         env:
           args: ${{ toJSON(matrix.gradle_args) }}
+          STONECUTTER_CONFIG_JSON: ${{ matrix.stonecutter_config }}
         run: |
           # Build each task
           mapfile -t args < <( echo "$args" | jq --raw-output .[] )

--- a/ci/src/build_matrix.test.ts
+++ b/ci/src/build_matrix.test.ts
@@ -3,37 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 
 import FIXTURES from "./fixtures.test.ts";
-import {
-  buildVersionMatrix,
-  loadMatrixJobs,
-  loadVersions,
-} from "./build_matrix.ts";
-
-describe("loadVersions", () => {
-  it("valid", () => {
-    const versions = loadVersions(
-      "versions",
-      path.resolve(FIXTURES, "valid_versions.toml"),
-    );
-
-    assert.equal(typeof versions, "object");
-
-    for (const [key, value] of Object.entries(versions)) {
-      assert.equal(typeof key, "string");
-      assert.ok(
-        value === null ||
-          (Array.isArray(value) &&
-            value.every((v) => typeof v === "string" || typeof v === "object")),
-      );
-    }
-  });
-
-  it("invalid", () => {
-    assert.throws(() =>
-      loadVersions("versions", path.resolve(FIXTURES, "invalid_versions.toml")),
-    );
-  });
-});
+import { buildVersionMatrix, loadMatrixJobs } from "./build_matrix.ts";
 
 describe("buildVersionMatrix", () => {
   it("basic", () => {
@@ -42,7 +12,12 @@ describe("buildVersionMatrix", () => {
       "1.20": ["common", "fabric", "forge"],
     };
 
-    const matrix = buildVersionMatrix("1.2.3", versions);
+    const config = {
+      vcs: "1.21",
+      versions,
+    };
+
+    const matrix = buildVersionMatrix("1.2.3", config);
 
     assert.equal(matrix.length, 2);
 
@@ -53,6 +28,10 @@ describe("buildVersionMatrix", () => {
     const job121 = matrix.find((j) => j.name === "MC 1.21");
     assert.ok(job121);
     assert.deepEqual(job121.gradle_args, [":neoforge:1.21:buildAndCollect"]);
+    assert.equal(
+      job121.stonecutter_config,
+      JSON.stringify({ vcs: "1.21", versions: { "1.21": versions["1.21"] } }),
+    );
 
     const job120 = matrix.find((j) => j.name === "MC 1.20");
     assert.ok(job120);
@@ -61,6 +40,10 @@ describe("buildVersionMatrix", () => {
       ":forge:1.20:buildAndCollect",
     ]);
     assert.equal(job120.upload?.name, "mc-1.20");
+    assert.equal(
+      job120.stonecutter_config,
+      JSON.stringify({ vcs: "1.21", versions: { "1.20": versions["1.20"] } }),
+    );
   });
 });
 

--- a/ci/src/build_matrix.ts
+++ b/ci/src/build_matrix.ts
@@ -1,16 +1,15 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import TOML from "smol-toml";
 import {
+  type MatrixJob,
   MatrixJobSchema,
   MatrixJobsFileSchema,
-  type MatrixJob,
 } from "./matrix_model.ts";
 import {
   SCProjectsByVersionSchema,
   SCProjectSlugSchema,
-  type SCProjectsByVersion,
 } from "./stonecutter_model.ts";
-import { MATRIX_JOBS_FILE, STONECUTTER_FILE } from "./project_files.ts";
+import { MATRIX_JOBS_FILE } from "./project_files.ts";
 import { readVersion } from "./read_version.ts";
 import app, { type CliOptions } from "./build_matrix_cli.ts";
 import { run, type StricliProcess } from "@stricli/core";
@@ -18,9 +17,10 @@ import { run, type StricliProcess } from "@stricli/core";
 export function main(args: CliOptions) {
   const version = args.version ?? readVersion();
 
+  const config = TOML.parse(readFileSync(args.versionsFile, "utf8"));
   const versionJobs = buildVersionMatrix(
     version + (args.release ? "" : "-SNAPSHOT"),
-    loadVersions("versions", args.versionsFile),
+    config,
   );
 
   const changelogJobs = args.changelog
@@ -52,10 +52,14 @@ export function main(args: CliOptions) {
 
 export function buildVersionMatrix(
   version: string,
-  versions: Record<string, unknown>,
+  config: Record<string, unknown>,
+  versionsKey = "versions",
 ): MatrixJob[] {
   const loaders = ["fabric", "forge", "neoforge"];
   const matrix: MatrixJob[] = [];
+
+  // Extract and validate directly where the context is used
+  const versions = SCProjectsByVersionSchema.parse(config[versionsKey]);
 
   for (const [key, branches] of Object.entries(versions)) {
     if (!Array.isArray(branches)) continue;
@@ -66,10 +70,17 @@ export function buildVersionMatrix(
       .filter((loader) => branches.includes(loader))
       .map((loader) => `:${loader}:${entry.project}:buildAndCollect`);
 
+    // Create a filtered copy of the stonecutter configuration
+    const jobConfig = {
+      ...config,
+      [versionsKey]: { [key]: branches },
+    };
+
     matrix.push(
       MatrixJobSchema.parse({
         name: `MC ${entry.project}`,
         gradle_args: gradleArgs,
+        stonecutter_config: JSON.stringify(jobConfig),
         upload: {
           name: `mc-${entry.project}`,
           path: `build/libs/${version}/*.jar`,
@@ -100,15 +111,6 @@ export function buildChangelogJob(
     ],
     upload: { path: `changelog/build/${file}`, days: 90, archive: false },
   };
-}
-
-export function loadVersions(
-  key = "versions",
-  file = STONECUTTER_FILE,
-): SCProjectsByVersion {
-  const toml = readFileSync(file, "utf8");
-  const versions = TOML.parse(toml)[key];
-  return SCProjectsByVersionSchema.parse(versions);
 }
 
 export function loadMatrixJobs(

--- a/ci/src/matrix_model.ts
+++ b/ci/src/matrix_model.ts
@@ -28,6 +28,7 @@ export const MatrixUploadSchema = z
 export const MatrixJobSchema = z.object({
   name: z.string(),
   gradle_args: z.array(z.string()),
+  stonecutter_config: z.string().optional(),
   upload: MatrixUploadSchema.optional(),
 });
 

--- a/ci/src/stonecutter_model.test.ts
+++ b/ci/src/stonecutter_model.test.ts
@@ -1,7 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { SCProjectSlugSchema } from "./stonecutter_model.ts";
+import {
+  SCProjectsByVersionSchema,
+  SCProjectSlugSchema,
+} from "./stonecutter_model.ts";
+import path from "node:path";
+import FIXTURES from "./fixtures.test.ts";
+import TOML from "smol-toml";
+import { readFileSync } from "node:fs";
 
 describe("ProjectEntry", () => {
   it("string entries", () => {
@@ -14,5 +21,30 @@ describe("ProjectEntry", () => {
   it("invalid", () => {
     assert.throws(() => SCProjectSlugSchema.parse(123));
     assert.throws(() => SCProjectSlugSchema.parse({ version: "1.0" }));
+  });
+});
+
+describe("ProjectsByVersion", () => {
+  it("valid", () => {
+    const file = path.resolve(FIXTURES, "valid_versions.toml");
+    const config = TOML.parse(readFileSync(file, "utf8"));
+    const versions = SCProjectsByVersionSchema.parse(config.versions);
+
+    assert.equal(typeof versions, "object");
+
+    for (const [key, value] of Object.entries(versions)) {
+      assert.equal(typeof key, "string");
+      assert.ok(
+        value === null ||
+          (Array.isArray(value) &&
+            value.every((v) => typeof v === "string" || typeof v === "object")),
+      );
+    }
+  });
+
+  it("invalid", () => {
+    const file = path.resolve(FIXTURES, "invalid_versions.toml");
+    const config = TOML.parse(readFileSync(file, "utf8"));
+    assert.throws(() => SCProjectsByVersionSchema.parse(config.versions));
   });
 });

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
 org.gradle.jvmargs=-Xmx4G
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
 fabric.loom.multiProjectOptimisation=true
 
 # Internal repository retry settings

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import kotlin.io.path.createTempFile
+
 val isCi = System.getenv("CI") == "true"
 gradle.startParameter.isParallelProjectExecutionEnabled = !isCi
 gradle.startParameter.isBuildCacheEnabled = !isCi
@@ -52,7 +54,16 @@ plugins {
 }
 
 stonecutter {
-    create(rootProject, file("stonecutter.settings.toml"))
+    val configFile = System.getenv("STONECUTTER_CONFIG_JSON")
+        ?.takeUnless { it.isEmpty() }
+        ?.let { json ->
+            createTempFile(prefix = "stonecutter.settings", suffix = ".json").toFile().apply {
+                deleteOnExit()
+                writeText(json)
+            }
+        }
+        ?: file("stonecutter.settings.toml")
+    create(rootProject, configFile)
 }
 
 include("i18n")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,5 @@
 import kotlin.io.path.createTempFile
 
-val isCi = System.getenv("CI") == "true"
-gradle.startParameter.isParallelProjectExecutionEnabled = !isCi
-gradle.startParameter.isBuildCacheEnabled = !isCi
-gradle.startParameter.isConfigureOnDemand = !isCi
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
Inspired by discussion in [stonecutter#63](https://codeberg.org/stonecutter/stonecutter/issues/63).

Optimize Gradle configuration and execution performance in CI by reducing Gradle-project to the relevant Stonecutter versions, additionally make the Gradle optimizations unconditional instead of being disabled in CI.

### Minimized Stonecutter Configuration in CI

1. **build_matrix:** Updated `build_matrix.ts` to serialize a minimized, version-specific subset of the Stonecutter configuration for each individual matrix job (`stonecutter_config`).
1. **CI workflow:** Injected the serialized configuration into the CI environment as `STONECUTTER_CONFIG_JSON`.
1. **Gradle settings:** Teach `settings.gradle.kts` to use `STONECUTTER_CONFIG_JSON` if present, wiring it to Stonecutter via a tmp-file. This ensures Gradle only evaluates projects relevant to the current matrix slice rather than parsing the entire multi-version block upfront.

### Gradle Optimizations

Removed the `settings.gradle.kts` overrides that disabled performance options for CI. Instead, define the flags unconditionally in `gradle.properties`.

See https://docs.gradle.org/current/userguide/performance.html for more about Gradle caching and performance optimization.
