### PR TITLE
ci: enable Gradle performance flags unconditionally

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.caching=true
 org.gradle.configureondemand=true
+# TODO: org.gradle.configuration-cache=true
 org.gradle.parallel=true
 fabric.loom.multiProjectOptimisation=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
 org.gradle.jvmargs=-Xmx4G
+org.gradle.caching=true
+org.gradle.configureondemand=true
+org.gradle.parallel=true
 fabric.loom.multiProjectOptimisation=true
 
 # Internal repository retry settings

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,3 @@
-val isCi = System.getenv("CI") == "true"
-gradle.startParameter.isParallelProjectExecutionEnabled = !isCi
-gradle.startParameter.isBuildCacheEnabled = !isCi
-gradle.startParameter.isConfigureOnDemand = !isCi
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
Hopefully we don't need to gate these performance improvements behind `!isCi`. If CI here passes, we're good.

Extracted from and closes #553. I'll extract some of the `ci` test cleanup too, but simply enabling `org.gradle.configureondemand` in CI is enough to avoid Gradle configuring unrelated projects; no need for custom per-matrix-entry Stonecutter settings.

See:
- https://docs.gradle.org/current/userguide/performance.html
- https://docs.gradle.org/current/userguide/configuration_on_demand.html