### PR TITLE
build: shadow internal modules (`:cloth-config`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 This file is formatted as per [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and Freecam's versioning is based on [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- Squash "Cloth Config impl is now bundled" with "resolved Fabric Loader 'invalid version'" in full release -->
+
 ## [Unreleased]
 
 ### Added
 
 ### Changed
+
+- Our Cloth Config implementation is now bundled as part of the main mod, rather than as nested child mods ([561](https://github.com/MinecraftFreecam/Freecam/pull/561))
 
 ### Removed
 

--- a/build-logic/shadow/src/main/kotlin/freecam.shadow.gradle.kts
+++ b/build-logic/shadow/src/main/kotlin/freecam.shadow.gradle.kts
@@ -1,10 +1,56 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.xolt.freecam.shadow.tasks.NormalizeShadowBundleTask
+
 /**
  * Applying this plugin to a project will transitively pull in its classpath,
  * giving the project access to `:build-logic:shadow` classes.
  *
- * It also applies the GradleUp `shadow` plugin, for convenience.
+ * It also applies the GradleUp `shadow` plugin and configures it to use the
+ * `bundle` configuration.
  */
 
 plugins {
     id("com.gradleup.shadow")
+}
+
+/**
+ * Include a dependency in the `shadowJar` task.
+ *
+ * We avoid using the default `shadow` configuration, because it is pre-configured to inherit from other configurations.
+ */
+val bundle = configurations.create("bundle") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    isTransitive = false
+}
+
+val normalizeShadowBundleTask = tasks.register<NormalizeShadowBundleTask>("normalizeShadowBundle") {
+    description = "Normalize dependencies before bundling with Shadow"
+    inputFiles.from(bundle)
+}
+
+tasks.named<Jar>("jar") {
+    archiveClassifier = "minimal"
+}
+
+val shadowJar = tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier = null
+
+    // Don't use the `shadow` configuration
+    configurations = emptySet()
+    from(normalizeShadowBundleTask.map { it.outputFiles })
+
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    failOnDuplicateEntries = true
+}
+
+configurations {
+    named("apiElements") {
+        outgoing.artifacts.clear()
+        outgoing.artifact(shadowJar)
+    }
+    named("runtimeElements") {
+        outgoing.artifacts.clear()
+        outgoing.artifact(shadowJar)
+    }
 }

--- a/cloth-config/build.gradle.kts
+++ b/cloth-config/build.gradle.kts
@@ -1,5 +1,3 @@
-import net.fabricmc.loom.task.FabricModJsonV1Task
-
 plugins {
     alias(libs.plugins.fletchingtable.fabric)
     id("freecam.loom-adapter")
@@ -14,47 +12,4 @@ dependencies {
     // Loader project should provide their own :common and cloth-config dependencies
     compileOnly(project(path = commonNode.project.path, configuration = "namedElements"))
     modCompileOnly("me.shedaniel.cloth:cloth-config-fabric:${meta.deps["cloth"]}")
-}
-
-tasks {
-    // A fabric.mod.json file is required for fabricloader to know the library's `version`
-    val modJsonTask = register<FabricModJsonV1Task>("generateModJson") {
-        description = "Generate fabric.mod.json"
-
-        outputFile = layout.buildDirectory.dir("generated-mod-json").map {
-            it.file("fabric.mod.json")
-        }
-
-        json {
-            modId = "${meta.id}-cloth-config"
-            name = "${meta.name} Cloth Config GUI"
-            version = meta.version.toString()
-            description = "Provides a ${meta.name} Config GUI when Cloth Config is installed."
-            licenses = listOf(meta.license)
-
-            client()
-            // Currently bundled with Freecam, no need to specify a dependency
-            // recommends("cloth-config", meta.reqs["cloth"].toString())
-
-            customData = mapOf(
-                "modmenu" to mapOf(
-                    "parent" to meta.id,
-                    "badges" to listOf("library"),
-                ),
-            )
-        }
-    }
-
-    processResources {
-        from(modJsonTask)
-    }
-
-    jar {
-        // `GAMELIBRARY` is required to access Minecraft classes from ModLauncher 9 (1.17)
-        val modType = if (sc.current.parsed >= "1.17") "GAMELIBRARY" else "LIBRARY"
-        manifest.attributes(
-            "FMLModType" to modType,
-            "Automatic-Module-Name" to "${meta.id}.clothconfig",
-        )
-    }
 }

--- a/cloth-config/src/main/java/net/xolt/freecam/config/gui/ClothConfigScreenProvider.java
+++ b/cloth-config/src/main/java/net/xolt/freecam/config/gui/ClothConfigScreenProvider.java
@@ -1,9 +1,7 @@
-package net.xolt.freecam.clothconfig;
+package net.xolt.freecam.config.gui;
 
 import net.minecraft.client.gui.screens.Screen;
 import net.xolt.freecam.config.controller.ConfigControllerRegistry;
-import net.xolt.freecam.config.gui.ConfigScreenProvider;
-import net.xolt.freecam.config.gui.OptionalProvider;
 import net.xolt.freecam.config.model.ModConfigDTO;
 import org.jetbrains.annotations.Nullable;
 

--- a/cloth-config/src/main/java/net/xolt/freecam/config/gui/ModConfigScreenFactory.java
+++ b/cloth-config/src/main/java/net/xolt/freecam/config/gui/ModConfigScreenFactory.java
@@ -1,4 +1,4 @@
-package net.xolt.freecam.clothconfig;
+package net.xolt.freecam.config.gui;
 
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;

--- a/cloth-config/src/main/resources/META-INF/services/net.xolt.freecam.config.gui.ConfigScreenProvider
+++ b/cloth-config/src/main/resources/META-INF/services/net.xolt.freecam.config.gui.ConfigScreenProvider
@@ -1,1 +1,1 @@
-net.xolt.freecam.clothconfig.ClothConfigScreenProvider
+net.xolt.freecam.config.gui.ClothConfigScreenProvider

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,10 +1,12 @@
+import net.fabricmc.loom.configuration.IncludeConfigurations.nestJars
 import net.fabricmc.loom.task.FabricModJsonV1Task
-import org.gradle.kotlin.dsl.sc
+import net.fabricmc.loom.task.RemapJarTask
 
 plugins {
     alias(libs.plugins.fletchingtable.fabric)
     id("freecam.loom-adapter")
     id("freecam.loaders")
+    id("freecam.shadow")
 }
 
 fletchingTable {
@@ -99,11 +101,17 @@ loom {
     }
 }
 
+val finalJarTask = if (loomAdapter.hasMappings) tasks.named<RemapJarTask>("remapJar") else tasks.shadowJar
+
 tasks.register<Copy>("buildAndCollect") {
     group = "build"
-    from(loomAdapter.modJar.map { it.archiveFile })
+    from(finalJarTask.flatMap { it.archiveFile })
     into(rootProject.layout.buildDirectory.file("libs/${meta.buildDir}"))
     dependsOn(tasks.build)
+}
+
+tasks.generateReleaseMetadata {
+    artifactFileName = finalJarTask.flatMap { it.archiveFileName }
 }
 
 tasks {
@@ -167,7 +175,15 @@ tasks {
         inputs.properties("java_version" to meta.javaVersion)
     }
 
-    generateReleaseMetadata {
-        artifactFileName = loomAdapter.modJar.flatMap { it.archiveFileName }
+    if (loomAdapter.hasMappings) {
+        shadowJar {
+            archiveClassifier = "named"
+        }
+        named<RemapJarTask>("remapJar") {
+            inputFile = shadowJar.flatMap { it.archiveFile }
+            archiveClassifier = null
+        }
+    } else {
+        nestJars(project, shadowJar, configurations.include)
     }
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -65,8 +65,7 @@ dependencies {
     }
 
     sc.node.sibling("cloth-config")?.let {
-        include(it.project)
-        api(project(path = it.project.path, configuration = "namedElements"))
+        bundle(api(project(path = it.project.path, configuration = "namedElements"))!!)
 
         include(modApi("me.shedaniel.cloth:cloth-config-fabric") {
             version { prefer(meta.deps["cloth"]!!) }

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -3,9 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransfor
 import com.github.jengelman.gradle.plugins.shadow.transformers.PreserveFirstFoundResourceTransformer
 import io.github.z4kn4fein.semver.constraints.toMavenFormat
 import kotlinx.serialization.json.*
-import net.neoforged.moddevgradle.legacyforge.internal.MinecraftMappings
 import net.xolt.freecam.gradle.ForgeModsTomlTask
-import net.xolt.freecam.shadow.tasks.NormalizeShadowBundleTask
 import net.xolt.freecam.shadow.transformers.ModsTomlTransformer
 
 plugins {
@@ -60,22 +58,6 @@ legacyForge {
 }
 
 /**
- * Include a dependency in the `shadowJar` task.
- * For third-party libraries, use [include] instead to take advantage of Forge's JarJar system.
- *
- * We avoid using the default `shadow` configuration, because it is pre-configured to inherit from other configurations.
- */
-val bundle by configurations.creating {
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    isTransitive = false
-
-    attributes {
-        attribute(MinecraftMappings.ATTRIBUTE, objects.named(MinecraftMappings.NAMED))
-    }
-}
-
-/**
  * Wrapper for [jarJar] and [bundle].
  *
  * You **must** also [`relocate`](https://gradleup.com/shadow/configuration/relocation) third-party packages in `tasks.shadowJar`,
@@ -90,7 +72,7 @@ fun DependencyHandler.include(dependencyNotation: Any, shadowJarConfig: ShadowJa
     if (sc.eval(forgeVersion, ">=40.1.60")) {
         jarJar(dependencyNotation)
     } else {
-        add(bundle.name, dependencyNotation)
+        bundle(dependencyNotation)
         tasks.shadowJar { shadowJarConfig() }
     }
 }
@@ -236,8 +218,6 @@ tasks.processResources {
 }
 
 tasks.jar {
-    archiveClassifier = "minimal"
-
     manifest.attributes(
         "MixinConfigs" to mixinConfigNames.joinToString(","),
     )
@@ -245,19 +225,7 @@ tasks.jar {
     finalizedBy("reobfJar")
 }
 
-val normalizeShadowBundleTask = tasks.register<NormalizeShadowBundleTask>("normalizeShadowBundle") {
-    description = "Normalize dependencies before bundling with Shadow"
-    inputFiles.from(bundle)
-}
-
 tasks.shadowJar {
-    duplicatesStrategy = DuplicatesStrategy.FAIL
-    failOnDuplicateEntries = true
-    archiveClassifier = null
-
-    // Don't use the `shadow` configuration
-    configurations = emptySet()
-    from(normalizeShadowBundleTask.map { it.outputFiles })
     from(mixinRefmap)
     from(tasks.jarJar)
 
@@ -290,15 +258,4 @@ tasks.shadowJar {
 
 obfuscation {
     reobfuscate(tasks.shadowJar, sourceSets.main.get())
-}
-
-configurations {
-    apiElements {
-        outgoing.artifacts.clear()
-        outgoing.artifact(tasks.shadowJar)
-    }
-    runtimeElements {
-        outgoing.artifacts.clear()
-        outgoing.artifact(tasks.shadowJar)
-    }
 }

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -229,8 +229,6 @@ tasks.shadowJar {
     from(mixinRefmap)
     from(tasks.jarJar)
 
-    exclude("fabric.mod.json")
-
     filesMatching("META-INF/mods.toml") {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.fletchingtable.neoforge)
     id("freecam.loaders")
     id("freecam.fml")
+    id("freecam.shadow")
 }
 
 val mixinConfigNames = listOf(
@@ -77,9 +78,13 @@ sourceSets.main {
 
 tasks.register<Copy>("buildAndCollect") {
     group = "build"
-    from(tasks.jar.map { it.archiveFile })
+    from(tasks.shadowJar.flatMap { it.archiveFile })
     into(rootProject.layout.buildDirectory.file("libs/${meta.buildDir}"))
     dependsOn(tasks.build)
+}
+
+tasks.generateReleaseMetadata {
+    artifactFileName = tasks.shadowJar.flatMap { it.archiveFileName }
 }
 
 tasks.named("createMinecraftArtifacts") {
@@ -135,4 +140,8 @@ tasks.processResources {
     }
 
     inputs.properties("java_version" to meta.javaVersion)
+}
+
+tasks.shadowJar {
+    from(tasks.jarJar)
 }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
         val clothConstraint = requireNotNull(meta.reqs["cloth"]) {
             "Missing reqs.cloth for ${project.path}"
         }
-        jarJar(implementation(project(path = it.project.path, configuration = "namedElements")) as Any)
+        bundle(implementation(project(path = it.project.path, configuration = "namedElements"))!!)
         jarJar(implementation("me.shedaniel.cloth:cloth-config-neoforge") {
             version {
                 prefer(clothVersion)


### PR DESCRIPTION
Our `:cloth-config` module is not an external dependency, so there is no need to jar-in-jar it as a separate mod. Internal modules (i.e., Gradle sub-projects) can be bundled in a monolithic mod, using Shadow.

Extract common configuration from the existing `:forge` shadow+bundle into the `freecam.shadow` convention plugin and wire up `:fabric` and `:neoforge` to use it. Then switch usage of the `:cloth-config` dependency from jar-in-jar `include` to shadow-based `bundle`.
