### PR TITLE
build(release-metadata): aggregate via Gradle configurations

### DIFF
--- a/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
@@ -15,10 +15,17 @@ sourceSets {
     }
 }
 
-tasks {
-    register<ProjectReleaseMetadataTask>("generateReleaseMetadata") {
-        group = "publishing"
-        description = "Generates release metadata for publishing"
+val releaseMetadataTask = tasks.register<ProjectReleaseMetadataTask>("generateReleaseMetadata") {
+    group = "publishing"
+    description = "Generates release metadata for publishing"
+}
+
+configurations.create("releaseMetadataElements") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+
+    artifacts {
+        add(name, releaseMetadataTask.flatMap { it.outputFile })
     }
 }
 

--- a/build-logic/release-metadata/src/main/kotlin/freecam.release-metadata.gradle.kts
+++ b/build-logic/release-metadata/src/main/kotlin/freecam.release-metadata.gradle.kts
@@ -1,17 +1,13 @@
-import net.xolt.freecam.gradle.ProjectReleaseMetadataTask
 import net.xolt.freecam.gradle.ReleaseMetadataTask
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.withType
+
+val cfg = configurations.create("releaseMetadata") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
 
 tasks.register<ReleaseMetadataTask>("generateReleaseMetadata") {
     group = "publishing"
     description = "Generates release metadata for publishing"
 
-    projectMetadataFiles = subprojects.flatMap { subproject ->
-        subproject.tasks.withType<ProjectReleaseMetadataTask>().map { it.outputFile.get() }
-    }
-
-    dependsOn(subprojects.flatMap { subproject ->
-        subproject.tasks.withType<ProjectReleaseMetadataTask>()
-    })
+    projectMetadataFiles = cfg
 }

--- a/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
+++ b/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
@@ -10,9 +10,8 @@ import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 import net.xolt.freecam.model.*
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -52,7 +51,7 @@ abstract class ReleaseMetadataTask : DefaultTask() {
     abstract val githubTag: Property<String>
 
     @get:InputFiles
-    abstract val projectMetadataFiles: ListProperty<RegularFile>
+    abstract val projectMetadataFiles: ConfigurableFileCollection
 
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
@@ -68,7 +67,6 @@ abstract class ReleaseMetadataTask : DefaultTask() {
         modrinthId.convention(meta.map { it.modrinthId })
         githubTag.convention(meta.map { "v${it.releaseVersion}" })
         changelog.convention("")
-        projectMetadataFiles.convention(emptyList())
         outputFile.convention(version.flatMap {
             project.layout.buildDirectory.file("metadata/release-$it.json")
         })
@@ -92,9 +90,8 @@ abstract class ReleaseMetadataTask : DefaultTask() {
 
     @OptIn(ExperimentalSerializationApi::class)
     private fun aggregateVersionFiles() = runBlocking {
-        projectMetadataFiles.get()
+        projectMetadataFiles
             .asSequence()
-            .map { it.asFile }
             .filter { it.exists() }
             .map { file ->
                 async(Dispatchers.IO) { json.decodeFromStream<ProjectReleaseMetadata>(file.inputStream()) }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -103,6 +103,13 @@ val releaseNotes by configurations.registering {
 
 dependencies {
     releaseNotes(project(":changelog", configuration = "releaseNotes"))
+
+    sequenceOf("fabric", "forge", "neoforge")
+        .mapNotNull { sc.tree[it] }
+        .flatMap { it.nodes }
+        .forEach {
+            releaseMetadata(project(it.project.path, configuration = "releaseMetadataElements"))
+        }
 }
 
 tasks.generateReleaseMetadata {


### PR DESCRIPTION
I noticed that publish dry-run has been blank since we enabled additional performance flags in CI (#554). It seems like configureondemand causes the root project's `:generateReleaseMetadata` not to find the subproject tasks.

---

`subprojects` and cross-project `tasks.withType` queries are unreliable when `configureondemand` is enabled because non-target projects are not evaluated upfront.

To fix this while keeping project evaluation lazy:
- Walk the Stonecutter tree to explicitly declare dependencies on loader subproject configurations.
- Expose subproject task outputs as consumable artifact configurations (`releaseMetadataElements`).
- Switch `projectMetadataFiles` from `ListProperty<RegularFile>` to `ConfigurableFileCollection`. This allows assigning the configuration directly while automatically wiring implicit task dependencies.

