### PR TITLE
build(loaders): fix issues with declarative source/resource dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ $RECYCLE.BIN/
 .gradle
 .kotlin/
 build/
+generated-eval/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
@@ -68,6 +68,17 @@ repositories {
         )
         filter { includeGroup("com.terraformersmc") }
     }
+
+    // Manually register the LWJGL repository. Otherwise, Loom tries to inject it
+    // dynamically, causing premature repository resolution errors.
+    findByName("MavenCentralLWJGL") ?: exclusiveContent {
+        forRepositories(mavenCentral {
+            name = "MavenCentralLWJGL"
+            content { includeGroup("org.lwjgl") }
+        })
+        filter { includeGroup("org.lwjgl") }
+    }
+
     mavenCentral()
 }
 

--- a/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
@@ -4,15 +4,32 @@ plugins {
     id("freecam.common")
 }
 
+val extraJavaSources = configurations.create("extraJavaSources") {
+    description = "Additional Java sources added to the main source set."
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+val extraResources = configurations.create("extraResources") {
+    description = "Additional resources added to the main source set."
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 sourceSets {
     main {
-        // Manually depend on common's pre-processed sources.
-        // NOTE: loaders have no build dependency on common, so API/implementation
-        //  classes and transitive dependencies must be manually propagated.
-        val commonTasks = commonNode.project.tasks
-        java.srcDirs(commonTasks.named<Sync>("stonecutterGenerate").map { it.destinationDir })
-        resources.srcDirs(commonTasks.processResources.map { it.destinationDir })
+        java.srcDirs(extraJavaSources)
+        resources.srcDirs(extraResources)
     }
+}
+
+dependencies {
+    val commonPath = commonNode.project.path
+    // Manually depend on common's pre-processed sources.
+    // NOTE: loaders have no build dependency on common, so API/implementation
+    //  classes and transitive dependencies must be manually propagated.
+    extraJavaSources(project(path = commonPath, configuration = "generatedSourcesElements"))
+    extraResources(project(path = commonPath, configuration = "processedResourcesElements"))
 }
 
 val releaseMetadataTask = tasks.register<ProjectReleaseMetadataTask>("generateReleaseMetadata") {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -57,3 +57,27 @@ tasks.processResources {
 
     duplicatesStrategy = DuplicatesStrategy.FAIL
 }
+
+configurations.create("generatedSourcesElements") {
+    description = "Generated sources from the common project."
+    isCanBeConsumed = true
+    isCanBeResolved = false
+
+    artifacts {
+        add(name, tasks.stonecutterGenerate.map { it.destinationDir }) {
+            builtBy(tasks.stonecutterGenerate)
+        }
+    }
+}
+
+configurations.create("processedResourcesElements") {
+    description = "Processed resources from the common project."
+    isCanBeConsumed = true
+    isCanBeResolved = false
+
+    artifacts {
+        add(name, tasks.processResources.map { it.destinationDir }) {
+            builtBy(tasks.processResources)
+        }
+    }
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,3 +1,6 @@
+import net.fabricmc.loom.task.MigrateClassTweakerMappingsTask
+import net.fabricmc.loom.task.ValidateAccessWidenerTask
+
 plugins {
     alias(libs.plugins.fletchingtable.fabric)
     id("freecam.loom-adapter")
@@ -12,12 +15,18 @@ fletchingTable {
 }
 
 loom {
-    // Loom reads the AW during configuration, so the :stonecutterGenerate one is too late
-    // We still use the task-generated AW during the actual build
+    // Loom unfortunately uses accessWidenerPath for two different purposes:
+    // - AccessWidenerJarProcessor eagerly reads it while constructing parts of Loom's decompilation pipeline.
+    // - Other tasks use it as their default input.
+    //
+    // The first requires an eagerly-written file, while the second should consume the task-generated access widener.
+    //
+    // We cannot easily override AccessWidenerJarProcessor, so we set the global property to an eagerly-written file
+    // and explicitly configure loom's tasks below.
     accessWidenerPath = provider {
         stonecutter.process(
             file = rootDir.resolve("common/src/main/resources/freecam.accesswidener"),
-            destination = "build/generated-eval/freecam.accesswidener"
+            destination = "generated-eval/freecam.accesswidener"
         )
     }
 
@@ -42,6 +51,13 @@ dependencies {
     modCompileOnly(libs.fabric.loader)
     compileOnly(project(":config"))
     i18nResources(project(":i18n"))
+}
+
+// Since we set `loom.accessWidenerPath` to an eval-time written AW file above,
+// explicitly configure loom's tasks to use the task-generated AW file.
+tasks.processResources.map { it.destinationDir.resolve("freecam.accesswidener") }.let { awFile ->
+    tasks.withType<ValidateAccessWidenerTask> { accessWidener = awFile }
+    tasks.withType<MigrateClassTweakerMappingsTask> { inputFile = awFile }
 }
 
 tasks.processResources {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,6 +1,8 @@
 import net.fabricmc.loom.configuration.IncludeConfigurations.nestJars
 import net.fabricmc.loom.task.FabricModJsonV1Task
+import net.fabricmc.loom.task.MigrateClassTweakerMappingsTask
 import net.fabricmc.loom.task.RemapJarTask
+import net.fabricmc.loom.task.ValidateAccessWidenerTask
 
 plugins {
     alias(libs.plugins.fletchingtable.fabric)
@@ -78,12 +80,18 @@ dependencies {
 }
 
 loom {
-    // Loom reads the AW during configuration, so the :stonecutterGenerate one is too late
-    // We still use the task-generated AW during the actual build
+    // Loom unfortunately uses accessWidenerPath for two different purposes:
+    // - AccessWidenerJarProcessor eagerly reads it while constructing parts of Loom's decompilation pipeline.
+    // - Other tasks use it as their default input.
+    //
+    // The first requires an eagerly-written file, while the second should consume the task-generated access widener.
+    //
+    // We cannot easily override AccessWidenerJarProcessor, so we set the global property to an eagerly-written file
+    // and explicitly configure loom's tasks below.
     accessWidenerPath = provider {
         stonecutter.process(
             file = rootDir.resolve("common/src/main/resources/freecam.accesswidener"),
-            destination = "build/generated-eval/freecam.accesswidener"
+            destination = "generated-eval/freecam.accesswidener"
         )
     }
 
@@ -100,6 +108,13 @@ loom {
             ideConfigGenerated(false)
         }
     }
+}
+
+// Since we set `loom.accessWidenerPath` to an eval-time written AW file above,
+// explicitly configure loom's tasks to use the task-generated AW file.
+tasks.processResources.map { it.destinationDir.resolve("freecam.accesswidener") }.let { awFile ->
+    tasks.withType<ValidateAccessWidenerTask> { accessWidener = awFile }
+    tasks.withType<MigrateClassTweakerMappingsTask> { inputFile = awFile }
 }
 
 val finalJarTask = if (loomAdapter.hasMappings) tasks.named<RemapJarTask>("remapJar") else tasks.shadowJar


### PR DESCRIPTION
This PR resolves Configure on Demand and project lifecycle issues across the common->loader dependency graph, by replacing eager project task evaluation with idiomatic output-configurations. This reveals a latent issue with Fabric Loom's repository mutations, which we also workaround.

We previously avoided using output-configurations because we ran into recursive project resolution issues when `group` was defined at the project top-level. That's since been resolved, so we should do things correctly.

This resolves issues that often get masked by Gradle cache, that I noticed when adding the 26.3 version and noticing that its `processResources` task was not run correctly.

### Changes
1. **Loom Repository Workaround (`freecam.common`):**
   - Pre-emptively registers the `MavenCentralLWJGL` repository to prevent Fabric Loom from attempting runtime repository mutations that trigger Gradle immutability lock errors.

2. **Configuration-Based Source Sharing (`freecam.loaders` & `:common`):**
   - Replaced fragile, eager `commonNode.project.tasks` lookups in `sourceSets.main` with dedicated consumable and resolvable configurations (`generatedSourcesElements` / `processedResourcesElements`).
   - Ensures Gradle lazily wires task execution dependencies (`builtBy`) and correctly preserves Configure on Demand performance for inactive version branches.

3. **Use task-generated Loom AW file where possible:**
   - I noticed when testing the above changes that the eval-time written AW file was causing issues for some loom tasks.
   - Where possible, we explicitly wire-in the task-generated file instead.
