### PR TITLE
build(cloth-config): Architectury mirror

### DIFF
--- a/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
@@ -56,9 +56,10 @@ repositories {
         filter { includeGroupAndSubgroups("org.spongepowered") }
     }
     exclusiveContent {
-        forRepository {
-            maven("https://maven.shedaniel.me") { name = "Shedaniel" }
-        }
+        forRepositories(
+            maven("https://maven.shedaniel.me") { name = "Shedaniel" },
+            maven("https://maven.architectury.dev" ) { name = "Architectury" },
+        )
         filter { includeGroup("me.shedaniel.cloth") }
     }
     exclusiveContent {


### PR DESCRIPTION
If the Shedaniel repo is down or not up-to-date, the Architectury repo
may be available.
