### PR TITLE
build: drop deprecated `by registering` usage

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,11 +2,13 @@ plugins {
     `kotlin-dsl` apply false
 }
 
-val check by tasks.registering {
+tasks.register("check") {
+    description = "Runs all checks in subprojects"
     aggregateByName()
 }
 
-val test by tasks.registering {
+tasks.register("test") {
+    description = "Runs the test suite in subprojects"
     aggregateByName()
 }
 

--- a/build-logic/conventions/src/main/kotlin/freecam.atremapper.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.atremapper.gradle.kts
@@ -21,9 +21,10 @@ val mojMapFile = layout.buildDirectory.file("mappings/mojMap.txt")
 val namedToSrgFile = layout.buildDirectory.file("mappings/namedToSrg.tsrg")
 val processResources = tasks.named<ProcessResources>("processResources")
 
-val generateNamedToSrg by tasks.registering {
+val generateNamedToSrgTask = tasks.register("generateNamedToSrg") {
     group = "mappings"
-    dependsOn(downloadSrgMappings, downloadMojMappings)
+    description = "Generate a Named→SRG mapping file"
+    dependsOn(downloadSrgMappingsTask, downloadMojMappingsTask)
     outputs.file(namedToSrgFile)
 
     doLast {
@@ -51,8 +52,9 @@ val generateNamedToSrg by tasks.registering {
 }
 
 @OptIn(ExperimentalSerializationApi::class)
-val downloadMojMappings by tasks.registering {
+val downloadMojMappingsTask = tasks.register("downloadMojMappings") {
     group = "mappings"
+    description = "Download official Mojang mappings"
     outputs.file(mojMapFile)
 
     // Out of date when MC version changes
@@ -78,8 +80,9 @@ val downloadMojMappings by tasks.registering {
     }
 }
 
-val downloadSrgMappings by tasks.registering {
+val downloadSrgMappingsTask = tasks.register("downloadSrgMappings") {
     group = "mappings"
+    description = "Download SRG mappings"
     outputs.file(srgFile)
 
     // Out of date when MC version changes
@@ -102,11 +105,11 @@ val downloadSrgMappings by tasks.registering {
     }
 }
 
-val remapAtToSrg by tasks.registering {
+val remapAtToSrgTask = tasks.register("remapAtToSrg") {
     group = "mappings"
     description = "Remap AccessTransformer from named to SRG"
 
-    dependsOn(generateNamedToSrg)
+    dependsOn(generateNamedToSrgTask)
     mustRunAfter(processResources)
 
     // the unmapped file comes from fletching table, via processResources
@@ -148,7 +151,7 @@ val remapAtToSrg by tasks.registering {
 
 // Ensure we remap before MDG uses the accesstransformer
 tasks.matching { it.name == "createMinecraftArtifacts" }.configureEach {
-    dependsOn(remapAtToSrg)
+    dependsOn(remapAtToSrgTask)
 }
 
 fun remapAtLine(line: String, remapper: MappingTree): String {

--- a/changelog/build.gradle.kts
+++ b/changelog/build.gradle.kts
@@ -56,7 +56,7 @@ changelog {
     headerParserRegex = "(\\d+(?:\\.\\d+)+(?:-[-a-z]+(?:\\.\\d+)?)?)".toRegex()
 }
 
-val getReleaseNotes by tasks.registering(GetChangelogTask::class) {
+val releaseNotesTask = tasks.register<GetChangelogTask>("getReleaseNotes") {
     group = "changelog"
     description = "Builds the current release notes"
     changelog = project.changelog.instance
@@ -72,11 +72,11 @@ val getReleaseNotes by tasks.registering(GetChangelogTask::class) {
     }
 }
 
-val releaseNotes by configurations.registering {
+configurations.register("releaseNotes") {
     isCanBeConsumed = true
     isCanBeResolved = false
 
-    outgoing.artifacts(getReleaseNotes.map { it.outputs.files }) {
-        builtBy(getReleaseNotes)
+    outgoing.artifacts(releaseNotesTask.map { it.outputs.files }) {
+        builtBy(releaseNotesTask)
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -35,7 +35,7 @@ loom {
     }
 }
 
-val i18nResources by configurations.registering {
+val i18nResources = configurations.register("i18nResources") {
     description = "The i18n project language files"
     isCanBeResolved = true
     isCanBeConsumed = false

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -85,7 +85,7 @@ stonecutter parameters {
     }
 }
 
-val releaseNotes by configurations.registering {
+val releaseNotes = configurations.register("releaseNotes") {
     isCanBeConsumed = false
     isCanBeResolved = true
 }


### PR DESCRIPTION
Gradle's Kotlin delegates have been deprecated in Gradle 9.6: https://docs.gradle.org/9.6.0/userguide/upgrading_version_9.html#kotlin_dsl_delegated_properties
