### PR TITLE
build: fix Forge/NeoForge IDE run configs

### DIFF
--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -57,6 +57,18 @@ legacyForge {
     }
 }
 
+// `bundle` contains internal subprojects whose classes are part of Freecam itself (e.g. `:config`).
+// `finalBundle` extends `bundle` with external dependencies, when Jar-in-Jar is not available (e.g. `cloth-config`).
+configurations.create("finalBundle") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    isTransitive = false
+    extendsFrom(configurations.bundle)
+}.also { cfg ->
+    // Override the `normalizeShadowBundle` task's input
+    tasks.normalizeShadowBundle { inputFiles = cfg }
+}
+
 /**
  * Wrapper for [jarJar] and [bundle].
  *
@@ -72,7 +84,7 @@ fun DependencyHandler.include(dependencyNotation: Any, shadowJarConfig: ShadowJa
     if (sc.eval(forgeVersion, ">=40.1.60")) {
         jarJar(dependencyNotation)
     } else {
-        bundle(dependencyNotation)
+        add("finalBundle", dependencyNotation)
         tasks.shadowJar { shadowJarConfig() }
     }
 }
@@ -133,6 +145,11 @@ legacyForge {
     mods {
         register(meta.id) {
             sourceSet(sourceSets.main.get())
+
+            // Mark internal dependencies as part of the mod, so their classes are loaded in dev runs.
+            sourceSet(sourceSets.create("bundled") {
+                output.dir(configurations.bundle)
+            })
         }
     }
 }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -69,6 +69,11 @@ neoForge {
     mods {
         register(meta.id) {
             sourceSet(sourceSets.main.get())
+
+            // Mark internal dependencies as part of the mod, so their classes are loaded in dev runs.
+            sourceSet(sourceSets.create("bundled") {
+                output.dir(configurations.bundle)
+            })
         }
     }
 }


### PR DESCRIPTION
Now that internal modules are shadowed into the production JAR instead of included via jar-in-jar, they must be explicitly added to ModDevGradle's `mods` source sets. Otherwise, IDE runs and `:runClient` tasks will not load their classes at runtime.

Introduces `finalBundle` for legacy Forge, to distinguish between internal modules (attached to MDG source sets) and external dependencies (found naturally via `mods.toml` or `FMLModType` scanning).

See https://github.com/neoforged/ModDevGradle/issues/289#issuecomment-5269721014
