### PR TITLE
chore(neoforge): support new ModListScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Feedback and bug reports are greatly appreciated!
 
 ### Fixed
 
+- Fixed mod description translations not working on NeoForge 26.2 ([576](https://github.com/MinecraftFreecam/Freecam/pull/576))
+
 ## [1.4.1-beta.3] - 2026-07-29
 
 1.4.1 adds initial support for Minecraft 26.2 and a new 'Outline Player' feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Feedback and bug reports are greatly appreciated!
 
 ### Added
 
+- Added support for NeoForge's new 26.2+ mods list screen, meaning our icon is shown in the list ([576](https://github.com/MinecraftFreecam/Freecam/pull/576))
+
 ### Changed
 
 ### Removed

--- a/build-logic/api/src/main/kotlin/net/xolt/freecam/model/FmlModsToml.kt
+++ b/build-logic/api/src/main/kotlin/net/xolt/freecam/model/FmlModsToml.kt
@@ -40,6 +40,9 @@ data class FmlModEntry(
     val displayName: String,
     @TomlMultilineString
     val description: String? = null,
+    val bannerFile: String? = null,
+    val iconFile: String? = null,
+    val iconBlur: Boolean? = null,
     val logoFile: String? = null,
     val logoBlur: Boolean? = null,
     val authors: String? = null,

--- a/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.common.gradle.kts
@@ -83,6 +83,13 @@ repositories {
     mavenCentral()
 }
 
+val extraResources = configurations.create("extraResources") {
+    description = "Additional resources added to processResources."
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
 tasks.processResources {
+    from(extraResources)
     dependsOn(tasks.named("stonecutterGenerate"))
 }

--- a/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/freecam.loaders.gradle.kts
@@ -4,22 +4,22 @@ plugins {
     id("freecam.common")
 }
 
-val extraJavaSources = configurations.create("extraJavaSources") {
-    description = "Additional Java sources added to the main source set."
+val extraJavaSourceDirs = configurations.create("extraJavaSourceDirs") {
+    description = "Additional Java source directories added to the main source set."
     isCanBeConsumed = false
     isCanBeResolved = true
 }
 
-val extraResources = configurations.create("extraResources") {
-    description = "Additional resources added to the main source set."
+val extraResourceDirs = configurations.create("extraResourceDirs") {
+    description = "Additional resource directories added to the main source set."
     isCanBeConsumed = false
     isCanBeResolved = true
 }
 
 sourceSets {
     main {
-        java.srcDirs(extraJavaSources)
-        resources.srcDirs(extraResources)
+        java.srcDirs(extraJavaSourceDirs)
+        resources.srcDirs(extraResourceDirs)
     }
 }
 
@@ -28,8 +28,8 @@ dependencies {
     // Manually depend on common's pre-processed sources.
     // NOTE: loaders have no build dependency on common, so API/implementation
     //  classes and transitive dependencies must be manually propagated.
-    extraJavaSources(project(path = commonPath, configuration = "generatedSourcesElements"))
-    extraResources(project(path = commonPath, configuration = "processedResourcesElements"))
+    extraJavaSourceDirs(project(path = commonPath, configuration = "generatedSourcesElements"))
+    extraResourceDirs(project(path = commonPath, configuration = "processedResourcesElements"))
 }
 
 val releaseMetadataTask = tasks.register<ProjectReleaseMetadataTask>("generateReleaseMetadata") {

--- a/build-logic/fml-support/src/main/kotlin/net/xolt/freecam/gradle/dsl/NeoForgeModsTomlSpec.kt
+++ b/build-logic/fml-support/src/main/kotlin/net/xolt/freecam/gradle/dsl/NeoForgeModsTomlSpec.kt
@@ -4,6 +4,7 @@ import net.xolt.freecam.model.FmlAccessTransformerEntry
 import net.xolt.freecam.model.FmlDependencyType
 import net.xolt.freecam.model.FmlMixinEntry
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
@@ -47,7 +48,17 @@ abstract class NeoForgeModsTomlSpec @Inject constructor(objects: ObjectFactory) 
     )
 }
 
-abstract class NeoForgeModEntrySpec : ModEntrySpec()
+abstract class NeoForgeModEntrySpec : ModEntrySpec() {
+    @get:Input @get:Optional abstract val bannerFile: Property<String>
+    @get:Input @get:Optional abstract val iconFile: Property<String>
+    @get:Input @get:Optional abstract val iconBlur: Property<Boolean>
+
+    override fun toModel(modId: String) = super.toModel(modId).copy(
+        bannerFile = bannerFile.orNull,
+        iconFile = iconFile.orNull,
+        iconBlur = iconBlur.orNull,
+    )
+}
 
 abstract class NeoForgeDependencyEntrySpec @Inject constructor(objects: ObjectFactory) : DependencyEntrySpec() {
     @get:Input val type = objects.property<FmlDependencyType>().convention(FmlDependencyType.REQUIRED)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -35,12 +35,6 @@ loom {
     }
 }
 
-val extraResources = configurations.register("extraResources") {
-    description = "Extra resources files"
-    isCanBeResolved = true
-    isCanBeConsumed = false
-}
-
 val i18nResources = configurations.register("i18nResources") {
     description = "The i18n project language files"
     isCanBeResolved = true
@@ -68,9 +62,7 @@ tasks.processResources.map { it.destinationDir.resolve("freecam.accesswidener") 
 }
 
 tasks.processResources {
-    from(extraResources) {
-        rename("icon-128.png", "icon.png")
-    }
+    rename("icon-128.png", "icon.png")
 
     from(i18nResources) {
         into("assets/${meta.id}/lang")

--- a/i18n/build.gradle.kts
+++ b/i18n/build.gradle.kts
@@ -4,7 +4,14 @@ plugins {
 
 i18n {
     transform("${meta.id}.mod.description") {
+        // Fabric ModMenu — https://github.com/TerraformersMC/ModMenu#translation-api
         rename("modmenu.descriptionTranslation.${meta.id}")
+
+        // NeoForge 20.4.179 — https://github.com/neoforged/NeoForge/pull/649
+        // https://docs.neoforged.net/docs/1.21.1/resources/client/i18n#translating-mod-metadata
         rename("fml.menu.mods.info.description.${meta.id}")
+
+        // NeoForge 26.2.0.50-beta — https://github.com/neoforged/NeoForge/pull/3073
+        rename("neoforge.screen.mods.info.description.${meta.id}")
     }
 }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -30,6 +30,11 @@ neoForge {
 }
 
 dependencies {
+    if (sc.current.parsed >= "26.2") {
+        // In 26.2 NeoForge introduced a new ModListScreen, which shows a 24px icon.
+        // We use a 96px icon because it is a multiple of 24.
+        extraResources(project(":branding", configuration = "icon_96"))
+    }
     bundle(api(project(":config"))!!)
     sc.node.sibling("cloth-config")?.let {
         val clothVersion = requireNotNull(meta.deps["cloth"]) {
@@ -110,8 +115,15 @@ val generateModsTomlTask = tasks.register<NeoForgeModsTomlTask>("generateModsTom
             description = meta.description
             authors = meta.authors.joinToString(", ")
             displayURL = meta.homepageUrl.toString()
-            logoFile = "icon.png"
-            logoBlur = true
+            if (sc.current.parsed >= "26.2") {
+                bannerFile = "icon.png"
+                iconFile = "icon-96.png"
+                iconBlur = true
+            }
+            if (sc.current.parsed <= "26.2") {
+                logoFile = "icon.png"
+                logoBlur = true
+            }
         }
 
         dependency(meta.id, "minecraft") {

--- a/neoforge/versions/26.2/src/main/java/net/xolt/freecam/forge/ModDisplayInfoCompat.java
+++ b/neoforge/versions/26.2/src/main/java/net/xolt/freecam/forge/ModDisplayInfoCompat.java
@@ -1,0 +1,23 @@
+package net.xolt.freecam.forge;
+
+import net.minecraft.network.chat.Component;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.neoforge.client.gui.modlist.DefaultModDisplayInfo;
+
+public class ModDisplayInfoCompat extends DefaultModDisplayInfo {
+
+    public ModDisplayInfoCompat(ModContainer container) {
+        super(container);
+    }
+
+    /**
+     * NeoForge 26.2.0.50-beta introduced the new ModListScreen and associated ModDisplayInfo,
+     * however description translations were initially broken.
+     *
+     * @see <a href="https://github.com/neoforged/NeoForge/pull/3407">#3407</a>
+     */
+    @Override
+    public Component description() {
+        return Component.translatableWithFallback("neoforge.screen.mods.info.description." + id(), container().getModInfo().getDescription());
+    }
+}

--- a/neoforge/versions/26.2/src/main/java/net/xolt/freecam/forge/ModDisplayInfoHandler.java
+++ b/neoforge/versions/26.2/src/main/java/net/xolt/freecam/forge/ModDisplayInfoHandler.java
@@ -1,0 +1,24 @@
+package net.xolt.freecam.forge;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.gui.modlist.ModDisplayInfo;
+import net.xolt.freecam.Freecam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Mod(value = Freecam.MOD_ID, dist = Dist.CLIENT)
+public class ModDisplayInfoHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("Freecam/ModDisplayInfo");
+
+    public ModDisplayInfoHandler(ModContainer container) {
+        try {
+            container.registerExtensionPoint(ModDisplayInfo.class, new ModDisplayInfoCompat(container));
+        } catch (NoClassDefFoundError _) {
+            // Before 26.2.0.50-beta, NeoForge did not have a ModDisplayInfo class
+            LOGGER.warn("Unable to register ModDisplayInfo compatability extension. Consider updating NeoForge.");
+        }
+    }
+}

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -38,7 +38,7 @@ deps.modmenu = "20.0.1"
 deps.fabric_api = "0.152.2+26.2"
 reqs.fabric_loader = ">=0.18.0"
 
-deps.neoforge_version = "26.2.0.6-beta"
+deps.neoforge_version = "26.2.0.64"
 reqs.neoforge_version = ">=26.2.0-0"
 reqs.neoforge_loader = ">=1"
 
@@ -54,7 +54,7 @@ deps.modmenu = "18.0.0"
 deps.fabric_api = "0.145.4+26.1.2"
 reqs.fabric_loader = ">=0.18.0"
 
-deps.neoforge_version = "26.1.2.2-beta"
+deps.neoforge_version = "26.1.2.95"
 reqs.neoforge_version = ">=26.1.0-alpha"
 reqs.neoforge_loader = ">=1"
 
@@ -69,7 +69,7 @@ deps.fabric_api = "0.139.4+1.21.11"
 deps.modmenu = "17.0.0"
 reqs.fabric_loader = ">=0.14.0"
 
-deps.neoforge_version = "21.11.6-beta"
+deps.neoforge_version = "21.11.45"
 deps.neoforge_pr = ""
 reqs.neoforge_version = ">=21.9.0-beta"
 reqs.neoforge_loader = ">=1"


### PR DESCRIPTION
#### Adds the new `description` translation key

But it turns out translations are broken in NeoForge 26.2, see https://github.com/neoforged/NeoForge/pull/3407

Temporarily included a mixin for testing. This is incompatible with earlier NeoForge betas and must be removed before merge.

#### With a banner file
<img width="904" height="567" alt="Screenshot From 2026-08-12 23-56-06" src="https://github.com/user-attachments/assets/f9c7b37d-f330-4bb9-9f19-e216726121ee" />

#### Without a banner file
<img width="904" height="567" alt="Screenshot From 2026-08-12 23-55-42" src="https://github.com/user-attachments/assets/cab62611-01d1-4bc7-8305-4a22ae27a637" />

_(excuse the german screenshots, I was testing mod description translation issues)_

#### TODO: dedicated banner image

(i.e. wider, not square)

#### TODO: bump cloth-config

Currently, NeoForge complains that cloth-config is still using `logoFile`. See https://github.com/shedaniel/cloth-config/pull/367
> [!note]
> The NeoForge warning is only shown in dev environments; users are only affected by the missing icon - they don't get a loud deprecation warning.