### PR TITLE
chore: drop broken `:build-logic` tasks & commit IDE run configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # User-specific stuff
 .idea/*
 !/.idea/icon.svg
+!.idea/runConfigurations
+# Loom generated
+/.idea/runConfigurations/*_fabric_*
+# Stonecutter generated
+/.idea/runConfigurations/Stonecutter_switchTo*.xml
+/.idea/runConfigurations/Reset_stonecutter_project.xml
 
 *.iml
 *.ipr

--- a/.idea/runConfigurations/Patch_Changelog.xml
+++ b/.idea/runConfigurations/Patch_Changelog.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Patch Changelog" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="externalProjectPath" value="$PROJECT_DIR$/changelog" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":patchChangelog" />
+        </list>
+      </option>
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/build_logic_check.xml
+++ b/.idea/runConfigurations/build_logic_check.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build-logic [check]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/build-logic" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="check" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/build_logic_test.xml
+++ b/.idea/runConfigurations/build_logic_test.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build-logic [test]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/build-logic" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,19 +1,3 @@
 plugins {
     `kotlin-dsl` apply false
 }
-
-tasks.register("check") {
-    description = "Runs all checks in subprojects"
-    aggregateByName()
-}
-
-tasks.register("test") {
-    description = "Runs the test suite in subprojects"
-    aggregateByName()
-}
-
-fun Task.aggregateByName() {
-    dependsOn(provider {
-        subprojects.mapNotNull { it.tasks.findByName(name) }
-    })
-}

--- a/ci/matrix_jobs.toml
+++ b/ci/matrix_jobs.toml
@@ -5,7 +5,7 @@ gradle_args = [":config:check"]
 
 [[build]]
 name = "Tooling"
-gradle_args = ["--project-dir", "build-logic", ":check"]
+gradle_args = ["--project-dir", "build-logic", "check"]
 
 [[build]]
 name = "Release metadata"


### PR DESCRIPTION
- **build: remove `:test` & `:check` aggregation**

These `:build-logic:test` and `:build-logic:check` task aggregrators were broken by Gradle Configure On Demand. We don't actually need them, because we can run `check` (without the `:`) if we specify `--project-dir build-logic`.

- **chore: commit `build-logic` IDE run configs**

To make the above more convenient, commit the relevant IDE run configs instead of completely ignoring `.idea/runConfigurations`.

- **chore: commit `Patch Changelog` IDE run config**

I've had this locally to make releasing easier. No reason not to commit it.
