### PR TITLE
doc(neoforge-26.2): reference upstream fix version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Feedback and bug reports are greatly appreciated!
 
 ### Fixed
 
-- Fixed mod description translations not working on NeoForge 26.2 ([576](https://github.com/MinecraftFreecam/Freecam/pull/576))
+- Fixed mod description translations not working on NeoForge 26.2.0.50–26.2.0.65 ([576](https://github.com/MinecraftFreecam/Freecam/pull/576))
 
 ## [1.4.1-beta.3] - 2026-07-29
 

--- a/neoforge/versions/26.2/src/main/java/net/xolt/freecam/forge/ModDisplayInfoCompat.java
+++ b/neoforge/versions/26.2/src/main/java/net/xolt/freecam/forge/ModDisplayInfoCompat.java
@@ -13,6 +13,9 @@ public class ModDisplayInfoCompat extends DefaultModDisplayInfo {
     /**
      * NeoForge 26.2.0.50-beta introduced the new ModListScreen and associated ModDisplayInfo,
      * however description translations were initially broken.
+     * <p>
+     * This overrides {@link DefaultModDisplayInfo#description()} to backport the fix from 26.0.66
+     * to earlier versions.
      *
      * @see <a href="https://github.com/neoforged/NeoForge/pull/3407">#3407</a>
      */


### PR DESCRIPTION
The upstream description translation fix was merged in NeoForge 26.0.66, so update our changelog & JavaDoc to reference it.
