### PR TITLE
build(branding): loader projects handle icons; use correct scale for (Neo)Forge logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Feedback and bug reports are greatly appreciated!
 
 ### Changed
 
+- The mod logo in Forge & NeoForge builds now scales better ([590](https://github.com/MinecraftFreecam/Freecam/pull/590))
+
 ### Removed
 
 ### Fixed

--- a/branding/build.gradle.kts
+++ b/branding/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 val sourceDir = layout.projectDirectory.dir("src/main")
 
-svg.exportPngMatrix("icon", 24, 32, 48, 64, 96, 128, 192, 256, 512, 1024) {
+svg.exportPngMatrix("icon", 24, 32, 48, 64, 96, 100, 128, 192, 256, 512, 1024) {
     source = sourceDir.file("icon.svg")
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     loomAdapter.applyMojangMappings()
     modCompileOnly(libs.fabric.loader)
     compileOnly(project(":config"))
-    extraResources(project(":branding", configuration = "icon_128"))
     i18nResources(project(":i18n"))
 }
 
@@ -62,8 +61,6 @@ tasks.processResources.map { it.destinationDir.resolve("freecam.accesswidener") 
 }
 
 tasks.processResources {
-    rename("icon-128.png", "icon.png")
-
     from(i18nResources) {
         into("assets/${meta.id}/lang")
     }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
         exclude(module = "fabric-loader")
     }
 
+    // ModMenu renders the icon at (64px * GUI_SCALE)
+    extraResources(project(":branding", configuration = "icon_128"))
     bundle(api(project(":config"))!!)
 
     sc.node.sibling("cloth-config")?.let {
@@ -186,6 +188,8 @@ tasks {
 
     processResources {
         from(modJsonTask)
+
+        rename("icon-128.png", "icon.png")
 
         filesMatching("freecam-fabric.mixins.json5") {
             expand("mixinCompatLevel" to "JAVA_${meta.javaVersion}")

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -95,7 +95,9 @@ dependencies {
         artifact { classifier = "processor" }
     }
 
-    extraResources(project(":branding", configuration = "icon_128"))
+    // Forge's ModListScreen renders the Mod logo at 50px high
+    // We use a 100px icon to scale well.
+    extraResources(project(":branding", configuration = "icon_100"))
     bundle(api(project(":config"))!!)
 
     sc.node.sibling("cloth-config")?.let {
@@ -214,7 +216,7 @@ tasks.processResources {
         into("META-INF")
     }
 
-    rename("icon-128.png", "logo.png")
+    rename("icon-100.png", "logo.png")
 
     filesMatching("freecam-forge.mixins.json") {
         expand("mixinCompatLevel" to "JAVA_${meta.javaVersion}")

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
         artifact { classifier = "processor" }
     }
 
+    extraResources(project(":branding", configuration = "icon_128"))
     bundle(api(project(":config"))!!)
 
     sc.node.sibling("cloth-config")?.let {
@@ -185,7 +186,7 @@ val generateModsTomlTask = tasks.register<ForgeModsTomlTask>("generateModsToml")
             description = meta.description
             authors = meta.authors.joinToString(", ")
             displayURL = meta.homepageUrl.toString()
-            logoFile = "icon.png"
+            logoFile = "logo.png"
             logoBlur = true
         }
 
@@ -212,6 +213,8 @@ tasks.processResources {
     from(generateModsTomlTask) {
         into("META-INF")
     }
+
+    rename("icon-128.png", "logo.png")
 
     filesMatching("freecam-forge.mixins.json") {
         expand("mixinCompatLevel" to "JAVA_${meta.javaVersion}")

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -30,6 +30,7 @@ neoForge {
 }
 
 dependencies {
+    extraResources(project(":branding", configuration = "icon_128"))
     if (sc.current.parsed >= "26.2") {
         // In 26.2 NeoForge introduced a new ModListScreen, which shows a 24px icon.
         // We use a 96px icon because it is a multiple of 24.
@@ -116,12 +117,12 @@ val generateModsTomlTask = tasks.register<NeoForgeModsTomlTask>("generateModsTom
             authors = meta.authors.joinToString(", ")
             displayURL = meta.homepageUrl.toString()
             if (sc.current.parsed >= "26.2") {
-                bannerFile = "icon.png"
-                iconFile = "icon-96.png"
+                bannerFile = "banner.png"
+                iconFile = "icon.png"
                 iconBlur = true
             }
             if (sc.current.parsed <= "26.2") {
-                logoFile = "icon.png"
+                logoFile = "banner.png"
                 logoBlur = true
             }
         }
@@ -151,6 +152,13 @@ tasks.processResources {
     from(generateModsTomlTask) {
         into("META-INF")
     }
+
+    // For 26.2+, we use a 96px icon for the mod list icon (24px * 4)
+    rename("icon-96.png", "icon.png")
+
+    // For now, we use a 128px icon for the logo/banner
+    // TODO: introduce a dedicated banner (for 26.2+, use 50px high, <250px wide, or scaled up)
+    rename("icon-128.png", "banner.png")
 
     filesMatching("freecam-neoforge.mixins.json") {
         expand("mixinCompatLevel" to "JAVA_${meta.javaVersion}")

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -30,7 +30,9 @@ neoForge {
 }
 
 dependencies {
-    extraResources(project(":branding", configuration = "icon_128"))
+    // NeoForge's ModListScreen renders the Mod logo/banner at 50px high
+    // We use a 100px icon to scale well.
+    extraResources(project(":branding", configuration = "icon_100"))
     if (sc.current.parsed >= "26.2") {
         // In 26.2 NeoForge introduced a new ModListScreen, which shows a 24px icon.
         // We use a 96px icon because it is a multiple of 24.
@@ -156,9 +158,9 @@ tasks.processResources {
     // For 26.2+, we use a 96px icon for the mod list icon (24px * 4)
     rename("icon-96.png", "icon.png")
 
-    // For now, we use a 128px icon for the logo/banner
-    // TODO: introduce a dedicated banner (for 26.2+, use 50px high, <250px wide, or scaled up)
-    rename("icon-128.png", "banner.png")
+    // For now, we use the 100px icon for the logo/banner
+    // TODO: introduce a dedicated banner
+    rename("icon-100.png", "banner.png")
 
     filesMatching("freecam-neoforge.mixins.json") {
         expand("mixinCompatLevel" to "JAVA_${meta.javaVersion}")


### PR DESCRIPTION
Drop icons from `:common`, instead handle branding in loader projects. Rename icons differently, depending on loader-specific context.

Forge & NeoForge render the "logo" (now "banner") at 50px high, and as-of 26.2 no longer offers a blurred scaling option. Use a 100px icon for now, which will scale well.