### PR TITLE
refactor(branding): convert SVG to monochrome evenodd path

### DIFF
--- a/branding/build.gradle.kts
+++ b/branding/build.gradle.kts
@@ -1,19 +1,62 @@
 import org.gradle.internal.DefaultTaskExecutionRequest
+import java.awt.Color
 
 plugins {
     id("freecam.svg")
 }
 
 val sourceDir = layout.projectDirectory.dir("src/main")
+val iconBackground = Color(0x002a36)
+val iconForeground = Color(0x00607c)
+
+val Color.xmlHexRgb
+    get() = (rgb and 0xffffff).toHexString(HexFormat {
+        number {
+            prefix = "#"
+            minLength = 6
+            removeLeadingZeros = true
+        }
+    })
+
+val styleSheetTask = tasks.register("iconStyleSheet") {
+    description = "Generate the icon's CSS stylesheet"
+    inputs.properties("foreground" to iconForeground)
+    outputs.file(layout.buildDirectory.file("resources/icon.css"))
+    doLast {
+        outputs.files.singleFile.apply {
+            writeText("svg { color: ${iconForeground.xmlHexRgb}; }")
+        }
+    }
+}
 
 svg.exportPngMatrix("icon", 24, 32, 48, 64, 96, 100, 128, 192, 256, 512, 1024) {
     source = sourceDir.file("icon.svg")
+    userStylesheet = styleSheetTask.map { it.outputs.files.singleFile }
+    backgroundColor = iconBackground
 }
 
 val installProjectIconTask = tasks.register<Copy>("installProjectIcon") {
     description = "Install the IntelliJ IDEA project icon"
     from(sourceDir.file("icon.svg"))
     into(rootDir.resolve(".idea"))
+
+    inputs.properties(
+        "background" to iconBackground,
+        "foreground" to iconForeground,
+    )
+
+    filter { line ->
+        when {
+            line.startsWith("<svg ") ->
+                """
+                |$line
+                |  <rect width="100%" height="100%" fill="${iconBackground.xmlHexRgb}"/>
+                """.trimMargin()
+            line.contains("\"currentColor\"") ->
+                line.replace("\"currentColor\"", "\"${iconForeground.xmlHexRgb}\"")
+            else -> line
+        }
+    }
 }
 
 // Hack to make IntelliJ IDEA run installProjectIconTask on sync

--- a/branding/src/main/icon.svg
+++ b/branding/src/main/icon.svg
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <rect id="background" width="512" height="512" fill="#002a36"/>
   <path
     id="camera"
-    fill="#00607c"
+    fill="currentColor"
     fill-rule="evenodd"
     d="
       M240 252

--- a/branding/src/main/icon.svg
+++ b/branding/src/main/icon.svg
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
   <path
-    id="camera"
     fill="currentColor"
     fill-rule="evenodd"
     d="

--- a/branding/src/main/icon.svg
+++ b/branding/src/main/icon.svg
@@ -1,63 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <mask id="cutouts">
-      <rect width="100%" height="100%" fill="white"/>
-      <rect id="flash" x="338" y="186" width="78" height="22" rx="1" fill="black"/>
-      <circle id="outer-lens" cx="256" cy="278" r="88" fill="black"/>
-      <circle id="inner-lens" cx="256" cy="278" r="56" fill="white"/>
-      <path
-        id="f-glyph"
-        fill="black"
-        d="
-          M240 252
-          A1 1 0 0 1 241 251
-          H271
-          A1 1 0 0 1 272 252
-
-          V263
-          A1 1 0 0 1 271 264
-          H252
-
-          V273
-          H270
-          A1 1 0 0 1 271 274
-
-          V285
-          A1 1 0 0 1 270 286
-          H252
-
-          V307
-          A1 1 0 0 1 251 308
-          H241
-          A1 1 0 0 1 240 307
-
-          Z
-        "
-      />
-    </mask>
-  </defs>
   <rect id="background" width="512" height="512" fill="#002a36"/>
   <path
     id="camera"
-    mask="url(#cutouts)"
     fill="#00607c"
+    fill-rule="evenodd"
     d="
+      M240 252
+      A1 1 0 0 1 241 251
+      H271
+      A1 1 0 0 1 272 252
+      V263
+      A1 1 0 0 1 271 264
+      H252
+      V273
+      H270
+      A1 1 0 0 1 271 274
+      V285
+      A1 1 0 0 1 270 286
+      H252
+      V307
+      A1 1 0 0 1 251 308
+      H241
+      A1 1 0 0 1 240 307
+      Z
+
+      M312 278
+      A56 56 0 0 1 200 278
+      A56 56 0 0 1 312 278
+      Z
+
+      M344 278
+      A88 88 0 0 1 168 278
+      A88 88 0 0 1 344 278
+      Z
+
+      M339 186
+      H415
+      A1 1 0 0 1 416 187
+      V207
+      A1 1 0 0 1 415 208
+      H339
+      A1 1 0 0 1 338 207
+      V187
+      A1 1 0 0 1 339 186
+      Z
+
       M80 190
       C80 175 83 170 104 170
-
       H185
       A1 1 0 0 0 186 169
       C190 134 190 128 209 128
-
       H303
       C322 128 322 134 327 170
       H412
-
       C429 170 432 175 432 190
       V366
       C432 381 430 386 412 386
-
       H100
       C82 386 80 381 80 366
       Z


### PR DESCRIPTION
Although harder to maintain, due to lack of granular IDs and self-documenting shapes, a single `<path>` with `"evenodd"` fill-rule is mathematically simpler and has much wider support.

Extracted from #580, remove colours from the icon SVG, meaning the icon now only defines shape and inherits `currentColor` from context. This will simplify eventual re-use in (e.g.) the website.
