### PR TITLE
ci: freecam-publish 0.0.6; separate release notes from metadata

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     with:
-      changelog: ${{ github.event_name != 'push' }}
+      changelog_comment: ${{ github.event_name != 'push' }}
       release: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
       matrix: true
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     with:
-      changelog: true
+      changelog_comment: true
       i18n: true
 
 
@@ -107,7 +107,7 @@ jobs:
       pull-requests: write # For posting comments
 
     steps:
-      - name: Wait for changelog
+      - name: Wait for release notes
         id: find
         if: needs.prepare.outputs.changelog_comment
         timeout-minutes: 11 # deadline + 1
@@ -130,13 +130,13 @@ jobs:
               }
             })()
 
-            // Due to Java & Gradle setup, the changelog usually takes ~1m to build.
+            // Due to Java & Gradle setup, release notes usually takes ~1m to build.
             // Wait 45s before polling, to reduce wasteful API calls.
             core.info("Waiting 45s before starting...")
             await sleep(45_000)
 
-            core.info("Polling for changelog.md")
-            const changelog = await (async () => {
+            core.info("Polling for release-notes.md")
+            const artifact = await (async () => {
               while (Date.now() < deadline) {
                 const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                   owner,
@@ -144,19 +144,19 @@ jobs:
                   run_id,
                 })
 
-                const match = artifacts.data.artifacts.find(a => a.name === "changelog.md")
+                const match = artifacts.data.artifacts.find(a => a.name === "release-notes.md")
                 if (match) return match
 
                 await backoff()
               }
             })()
 
-            if (!changelog) {
-              core.setFailed("Timed out waiting for changelog artifact")
+            if (!artifact) {
+              core.setFailed("Timed out waiting for release notes artifact")
               return
             }
 
-            core.setOutput("id", changelog.id)
+            core.setOutput("id", artifact.id)
 
       - name: Download artifact
         id: download
@@ -182,7 +182,7 @@ jobs:
             const body = (function() {
               try {
                  return marker + "\n\n# 📦 Changelog\n\n"
-                     + readFileSync("changelog.md", "utf8")
+                     + readFileSync("release-notes.md", "utf8")
               } catch (err) {
                 if (err.code !== 'ENOENT') throw err
                 return null

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -3,7 +3,7 @@ name: Setup
 on:
   workflow_call:
     inputs:
-      changelog:
+      changelog_comment:
         description: Check whether a changelog comment should be posted
         type: boolean
         default: false
@@ -47,7 +47,7 @@ env:
   # Scopes that can be queried using `contains(env.scopes, 'scope')`
   scopes: >
     ${{ inputs.matrix && 'node' || '' }}
-    ${{ inputs.changelog && 'files' || '' }}
+    ${{ inputs.changelog_comment && 'files' || '' }}
     ${{ inputs.i18n && 'files' || '' }}
 
 jobs:
@@ -65,7 +65,7 @@ jobs:
       do_release: ${{ steps.check_release.outputs.do_release }}
       changelog_comment: >-
         ${{
-          steps.changed_files.outputs.changelog ||
+          steps.changed_files.outputs.changelog_comment ||
           steps.check_release.outputs.unreleased
         }}
       i18n_files: ${{ steps.changed_files.outputs.i18n }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Check whether this version is released
         id: check_release
-        if: inputs.release || inputs.changelog
+        if: inputs.release || inputs.changelog_comment || inputs.matrix
         uses: actions/github-script@v9
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -173,11 +173,11 @@ jobs:
         id: matrix
         if: inputs.matrix
         env:
-          touches_changelog: ${{ steps.changed_files.outputs.changelog }}
           unreleased: ${{ steps.check_release.outputs.unreleased }}
           version: ${{ steps.version.outputs.version }}
         run: |
           args=(
+            --changelog
             --version "$version"
             --output matrix.json
           )
@@ -185,11 +185,6 @@ jobs:
           # If 'unreleased' is set, that means the version has been bumped, so do a release build.
           if [ -n "$unreleased" ]; then
             args+=( --release )
-          fi
-
-          # For PRs that touch the changelog or trigger a release, we build the changelog preview comment.
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$touches_changelog$unreleased" ]; then
-              args+=( --changelog )
           fi
 
           node ci/src/build_matrix.ts "${args[@]}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,14 +62,13 @@ jobs:
 
           version=$(jq .mod_version "$meta" --raw-output)
           title=$(jq .display_name "$meta" --raw-output)
-          jq .changelog "$meta" --raw-output > changelog.md
 
           args=(
             --repo "$GITHUB_REPOSITORY"
             release create "v$version"
             --target "$ref"
             --title "$title"
-            --notes-file changelog.md
+            --notes-file artifacts/release-notes.md
           )
 
           jq '.release_type == "release"' "$meta" --exit-status >/dev/null || {
@@ -93,7 +92,7 @@ jobs:
           distribution: temurin
 
       - name: Setup Freecam Publisher
-        uses: MinecraftFreecam/Publisher@v0.0.5
+        uses: MinecraftFreecam/Publisher@v0.0.6
 
       - name: Publish to CurseForge & Modrinth
         env:

--- a/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
+++ b/build-logic/release-metadata/src/main/kotlin/net/xolt/freecam/gradle/ReleaseMetadataTask.kt
@@ -30,9 +30,6 @@ abstract class ReleaseMetadataTask : DefaultTask() {
     }
 
     @get:Input
-    abstract val changelog: Property<String>
-
-    @get:Input
     abstract val version: Property<String>
 
     @get:Input
@@ -66,7 +63,6 @@ abstract class ReleaseMetadataTask : DefaultTask() {
         curseforgeId.convention(meta.map { it.curseforgeId.toLong() })
         modrinthId.convention(meta.map { it.modrinthId })
         githubTag.convention(meta.map { "v${it.releaseVersion}" })
-        changelog.convention("")
         outputFile.convention(version.flatMap {
             project.layout.buildDirectory.file("metadata/release-$it.json")
         })
@@ -78,7 +74,6 @@ abstract class ReleaseMetadataTask : DefaultTask() {
             modVersion = version.get(),
             releaseType = releaseType.get(),
             displayName = displayName.get(),
-            changelog = changelog.get(),
             versions = aggregateVersionFiles(),
             platforms = Platforms(
                 curseforge = Platforms.Curseforge(curseforgeId.get().toULong()),

--- a/changelog/build.gradle.kts
+++ b/changelog/build.gradle.kts
@@ -68,7 +68,7 @@ val releaseNotesTask = tasks.register<GetChangelogTask>("getReleaseNotes") {
     unreleased = false
 
     outputFile = project.changelog.version.flatMap { version ->
-        project.layout.buildDirectory.file("build/$version/changelog.md")
+        project.layout.buildDirectory.file("build/$version/release-notes.md")
     }
 }
 

--- a/ci/src/build_matrix.ts
+++ b/ci/src/build_matrix.ts
@@ -26,15 +26,15 @@ export function main(args: CliOptions) {
     SCProjectsByVersionSchema.parse(versionsToml.versions),
   );
 
-  const changelogJobs = args.changelog
-    ? [buildChangelogJob(args.release, version)]
+  const releaseNotesJobs = args.changelog
+    ? [buildReleaseNotesJob(args.release, version)]
     : [];
 
   const staticJobs = matrixJobsToml
     ? MatrixJobsFileSchema.parse(matrixJobsToml).builds
     : [];
 
-  const matrix = [...changelogJobs, ...staticJobs, ...versionJobs].sort(
+  const matrix = [...releaseNotesJobs, ...staticJobs, ...versionJobs].sort(
     (a, b) => a.name.localeCompare(b.name),
   );
 
@@ -84,21 +84,24 @@ export function buildVersionMatrix(
   return matrix;
 }
 
-export function buildChangelogJob(
+export function buildReleaseNotesJob(
   release = false,
   version?: string,
-  file = "changelog.md",
+  file = "release-notes.md",
 ): MatrixJob {
   if (release && !version) {
-    throw new Error("buildChangelogJob: version is required when release=true");
+    throw new Error(
+      "buildReleaseNotesJob: version is required when release=true",
+    );
   }
 
   return {
-    name: "Changelog",
+    name: "Release Notes",
     gradle_args: [
       "--project-dir=changelog",
       ":getChangelog",
       release ? `--project-version=${version}` : "--unreleased",
+      "--no-header",
       `--output-file=build/${file}`,
     ],
     upload: { path: `changelog/build/${file}`, days: 90, archive: false },

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.4.0"
 shadow = "9.5.1"
-freecam-publisher = "v0.0.5"
+freecam-publisher = "v0.0.6"
 stonecutter = "0.9.3"
 fabric-loom = "1.17-SNAPSHOT"
 fabric-loader = "0.19.3"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -85,29 +85,13 @@ stonecutter parameters {
     }
 }
 
-val releaseNotes = configurations.register("releaseNotes") {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-}
-
 dependencies {
-    releaseNotes(project(":changelog", configuration = "releaseNotes"))
-
     sequenceOf("fabric", "forge", "neoforge")
         .mapNotNull { sc.tree[it] }
         .flatMap { it.nodes }
         .forEach {
             releaseMetadata(project(it.project.path, configuration = "releaseMetadataElements"))
         }
-}
-
-tasks.generateReleaseMetadata {
-    changelog = releaseNotes.map { it.singleFile.readText() }
-
-    // FIXME: the :changelog outgoing artifact should encode its dependencies,
-    //  this project shouldn't need to know about the underlying task.
-    //  See https://github.com/gradle/gradle/issues/24131
-    dependsOn(gradle.includedBuild("changelog").task(":getReleaseNotes"))
 }
 
 tasks.named<Wrapper>("wrapper") {


### PR DESCRIPTION
Bump freecam-publish to 0.0.5, which brings in schema 0.1.0. This drops the `changelog` `ReleaseMetadata` field, so we drop the corresponding `ReleaseMetadataTask` property.

Now, the publisher expects a `release-notes.md` file. We already build this for the PR changelog sticky comment, so adapt that pipeline so that we always have a release notes artifact in CI builds.
