### PR TITLE
fix: stop freecam from sinking when toggle sneak is enabled

### DIFF
--- a/common/src/main/java/net/xolt/freecam/mixins/KeyMappingAccessor.java
+++ b/common/src/main/java/net/xolt/freecam/mixins/KeyMappingAccessor.java
@@ -1,0 +1,13 @@
+package net.xolt.freecam.mixins;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(KeyMapping.class)
+public interface KeyMappingAccessor {
+
+    @Accessor("key")
+    InputConstants.Key freecam$getKey();
+}

--- a/common/src/main/java/net/xolt/freecam/util/Motion.java
+++ b/common/src/main/java/net/xolt/freecam/util/Motion.java
@@ -1,7 +1,11 @@
 package net.xolt.freecam.util;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
+import net.xolt.freecam.mixins.KeyMappingAccessor;
+
+import static net.xolt.freecam.Freecam.MC;
 
 public class Motion {
 
@@ -50,10 +54,31 @@ public class Motion {
         if (freeCamera.input.keyPresses.jump()) {
             velocityY += vSpeed;
         }
-        if (freeCamera.input.keyPresses.shift()) {
+        if (isSneakKeyDown(freeCamera)) {
             velocityY -= vSpeed;
         }
 
         freeCamera.setDeltaMovement(velocityX, velocityY, velocityZ);
+    }
+
+    // The sneak keybind can be set to toggle rather than hold (Options > Controls > Toggle Sneak).
+    // In that case, MC.options.keyShift.isDown() reflects whatever sneak state the player toggled
+    // to beforehand, not whether the key is currently held, causing the camera to drift down for as
+    // long as that stale toggle happens to be on. Poll the physical key state directly instead, so
+    // descending in freecam always requires actually holding the key down, regardless of the toggle
+    // sneak setting.
+    private static boolean isSneakKeyDown(FreeCamera freeCamera) {
+        //~ if >=26.2 screen -> 'gui.screen()'
+        if (MC.gui.screen() != null) {
+            return false;
+        }
+
+        InputConstants.Key key = ((KeyMappingAccessor) MC.options.keyShift).freecam$getKey();
+        if (key.getType() != InputConstants.Type.KEYSYM && key.getType() != InputConstants.Type.SCANCODE) {
+            // Not bound to a keyboard key (e.g. a mouse button); fall back to the mapping's own state.
+            return freeCamera.input.keyPresses.shift();
+        }
+
+        return InputConstants.isKeyDown(MC.getWindow(), key.getValue());
     }
 }

--- a/common/src/main/resources/freecam-common.mixins.json5
+++ b/common/src/main/resources/freecam-common.mixins.json5
@@ -20,6 +20,7 @@
     //? if <1.21.6
     //"IrisShadowRendererMixin",
     "ItemInHandRendererMixin",
+    "KeyMappingAccessor",
     //? if >=26.2 {
     "LevelExtractorMixin",
     //? } else if >=1.21.11


### PR DESCRIPTION
When Toggle Sneak is enabled (Options > Controls), the sneak
keybind becomes a toggle instead of a hold. Freecam's descend movement reads
that key's `isDown()` directly, so if sneak happened to be toggled on, the
camera would just sink forever with no way to stop it besides pressing sneak
again which also toggled the real player's crouch or by pressing jump key.

This makes freecam poll the sneak key's actual physical state instead,
independent of the toggle setting. Descending now works like holding jump to
ascend: only active while the key is actually held down.

Tested on Fabric 26.2. Compiles fine on the other supported versions too
(1.17.1 through 26.1, NeoForge 26.2), but I didn't run those in-game.
