### PR TITLE
fix: stop freecam from sinking when toggle sneak is enabled

### DIFF
--- a/.changeset/fix_toggle_sneak.md
+++ b/.changeset/fix_toggle_sneak.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Stop freecam from sinking when toggle sneak is enabled

--- a/common/src/main/java/net/xolt/freecam/Freecam.java
+++ b/common/src/main/java/net/xolt/freecam/Freecam.java
@@ -3,6 +3,7 @@ package net.xolt.freecam;
 import net.minecraft.client.CameraType;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.ToggleKeyMapping;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.player.KeyboardInput;
 import net.minecraft.network.chat.Component;
@@ -41,6 +42,7 @@ public class Freecam {
     private static TripodSlot activeTripod = TripodSlot.NONE;
     private static FreeCamera freeCamera;
     private static CameraType rememberedF5 = null;
+    private static boolean sneakStateOnEnable = false;
 
     @ApiStatus.Internal
     public static void preTick(Minecraft mc) {
@@ -254,6 +256,7 @@ public class Freecam {
     private static void onEnable() {
         MC.smartCull = false;
         outlineEnabled = ModConfig.get().shouldOutlinePlayer();
+        sneakStateOnEnable = MC.options.keyShift.isDown();
 
         rememberedF5 = MC.options.getCameraType();
         //~ if >=26.2 getMainCamera -> mainCamera
@@ -279,6 +282,18 @@ public class Freecam {
     private static void onDisabled() {
         if (rememberedF5 != null) {
             MC.options.setCameraType(rememberedF5);
+        }
+        restoreSneakState();
+    }
+
+    // Using the sneak key to descend in freecam (see Motion.isSneakKeyDown) still reaches the real
+    // keyShift mapping, so with Toggle Sneak enabled it silently flips the player's persisted crouch
+    // state in the background. Flip it back if it changed while freecam was open, so freecam's own
+    // camera controls never leak into the player's actual sneak state once freecam closes.
+    private static void restoreSneakState() {
+        KeyMapping keyShift = MC.options.keyShift;
+        if (keyShift instanceof ToggleKeyMapping && keyShift.isDown() != sneakStateOnEnable) {
+            keyShift.setDown(true);
         }
     }
 

--- a/common/src/main/java/net/xolt/freecam/util/Motion.java
+++ b/common/src/main/java/net/xolt/freecam/util/Motion.java
@@ -1,7 +1,10 @@
 package net.xolt.freecam.util;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
+
+import static net.xolt.freecam.Freecam.MC;
 
 public class Motion {
 
@@ -50,10 +53,32 @@ public class Motion {
         if (freeCamera.input.keyPresses.jump()) {
             velocityY += vSpeed;
         }
-        if (freeCamera.input.keyPresses.shift()) {
+        if (isSneakKeyDown(freeCamera)) {
             velocityY -= vSpeed;
         }
 
         freeCamera.setDeltaMovement(velocityX, velocityY, velocityZ);
+    }
+
+    // The sneak keybind can be set to toggle rather than hold (Options > Controls > Toggle Sneak).
+    // In that case, MC.options.keyShift.isDown() reflects whatever sneak state the player toggled
+    // to beforehand, not whether the key is currently held, causing the camera to drift down for as
+    // long as that stale toggle happens to be on. Poll the physical key state directly instead, so
+    // descending in freecam always requires actually holding the key down, regardless of the toggle
+    // sneak setting.
+    private static boolean isSneakKeyDown(FreeCamera freeCamera) {
+        //~ if >=26.2 screen -> 'gui.screen()'
+        if (MC.gui.screen() != null) {
+            return false;
+        }
+
+        InputConstants.Key key = MC.options.keyShift.key;
+        if (key.getType() != InputConstants.Type.KEYSYM && key.getType() != InputConstants.Type.SCANCODE) {
+            // Not bound to a keyboard key (e.g. a mouse button); fall back to the mapping's own state.
+            return freeCamera.input.keyPresses.shift();
+        }
+
+        //~ if <1.21.11 'MC.getWindow()' -> 'MC.getWindow().getWindow()'
+        return InputConstants.isKeyDown(MC.getWindow(), key.getValue());
     }
 }

--- a/common/src/main/resources/freecam.accesswidener
+++ b/common/src/main/resources/freecam.accesswidener
@@ -1,9 +1,9 @@
 accessWidener v2 official
+
+accessible field net/minecraft/client/KeyMapping key Lcom/mojang/blaze3d/platform/InputConstants$Key;
+
 #? if >=1.21
 accessible method net/minecraft/client/multiplayer/ClientPacketListener setClientLoaded (Z)V
 
 #? if <1.21
 #accessible field net/minecraft/client/renderer/entity/EntityRenderDispatcher shouldRenderShadow Z
-
-#? if <1.20
-#accessible field net/minecraft/client/KeyMapping key Lcom/mojang/blaze3d/platform/InputConstants$Key;


### PR DESCRIPTION
When Toggle Sneak is enabled (Options > Controls), the sneak
keybind becomes a toggle instead of a hold. Freecam's descend movement reads
that key's `isDown()` directly, so if sneak happened to be toggled on, the
camera would just sink forever with no way to stop it besides pressing sneak
again which also toggled the real player's crouch or by pressing jump key.

This makes freecam poll the sneak key's actual physical state instead,
independent of the toggle setting. Descending now works like holding jump to
ascend: only active while the key is actually held down.

Tested on Fabric 26.2. Compiles fine on the other supported versions too
(1.17.1 through 26.1, NeoForge 26.2), but I didn't run those in-game.
