### PR TITLE
ci(pr): auto-label PRs for release & CI changes

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -3,6 +3,10 @@ name: Setup
 on:
   workflow_call:
     inputs:
+      ci_files:
+        description: Check whether files in 'ci' or '.github' were touched
+        type: boolean
+        default: false
       i18n:
         description: Check whether i18n files were touched
         type: boolean
@@ -22,6 +26,9 @@ on:
       do_release:
         description: Whether to publish a GitHub Release
         value: ${{ jobs.prepare.outputs.do_release }}
+      ci_files:
+        description: Whether the PR touches files in 'ci' or '.github'
+        value: ${{ jobs.prepare.outputs.ci_files }}
       i18n_files:
         description: Whether the PR touches i18n files
         value: ${{ jobs.prepare.outputs.i18n_files }}
@@ -40,6 +47,7 @@ env:
   # Scopes that can be queried using `contains(env.scopes, 'scope')`
   scopes: >
     ${{ inputs.matrix && 'node' || '' }}
+    ${{ inputs.ci_files && 'files' || '' }}
     ${{ inputs.i18n && 'files' || '' }}
 
 jobs:
@@ -55,6 +63,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       do_release: ${{ steps.check_release.outputs.do_release }}
+      ci_files: ${{ steps.changed_files.outputs.ci }}
       i18n_files: ${{ steps.changed_files.outputs.i18n }}
       matrix: ${{ steps.matrix.outputs.matrix }}
 
@@ -118,6 +127,10 @@ jobs:
               }
             )
             const files = result.repository.pullRequest.files.nodes
+            if (files.some(f => f.path.startsWith("ci/") || f.path.startsWith(".github/"))) {
+              core.notice("This PR touches ci files")
+              core.setOutput("ci", "true")
+            }
             if (files.some(f => f.path.startsWith("i18n/"))) {
               core.notice("This PR touches i18n files")
               core.setOutput("i18n", "true")

--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -7,7 +7,7 @@ on:
         description: Check whether files in 'ci' or '.github' were touched
         type: boolean
         default: false
-      i18n:
+      i18n_files:
         description: Check whether i18n files were touched
         type: boolean
         default: false
@@ -48,7 +48,7 @@ env:
   scopes: >
     ${{ inputs.matrix && 'node' || '' }}
     ${{ inputs.ci_files && 'files' || '' }}
-    ${{ inputs.i18n && 'files' || '' }}
+    ${{ inputs.i18n_files && 'files' || '' }}
 
 jobs:
   prepare:

--- a/.github/workflows/pull_request_target.yaml
+++ b/.github/workflows/pull_request_target.yaml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
     with:
+      ci_files: true
       i18n: true
       release: true
 
@@ -44,13 +45,14 @@ jobs:
       - name: Compute managed labels
         shell: python
         env:
+          ci: ${{ needs.prepare.outputs.ci_files }}
           i18n: ${{ needs.prepare.outputs.i18n_files }}
           release: ${{ needs.prepare.outputs.do_release }}
         run: |
           import json
           import os
 
-          managed = ["i18n", "release"]
+          managed = ["ci", "i18n", "release"]
 
           labels = {
             label: os.environ.get(label) == "true"

--- a/.github/workflows/pull_request_target.yaml
+++ b/.github/workflows/pull_request_target.yaml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     with:
       ci_files: true
-      i18n: true
+      i18n_files: true
       release: true
 
   label:

--- a/.github/workflows/pull_request_target.yaml
+++ b/.github/workflows/pull_request_target.yaml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     with:
       i18n: true
+      release: true
 
   label:
     name: Label
@@ -44,11 +45,12 @@ jobs:
         shell: python
         env:
           i18n: ${{ needs.prepare.outputs.i18n_files }}
+          release: ${{ needs.prepare.outputs.do_release }}
         run: |
           import json
           import os
 
-          managed = ["i18n"]
+          managed = ["i18n", "release"]
 
           labels = {
             label: os.environ.get(label) == "true"


### PR DESCRIPTION
Adds `release` and `ci` label to the PR-label managing workflow. Update the `prepare` workflow to detect touched CI/workflow files and standardize `i18n_files` input naming.
