### PR TITLE
ci: orchestrate PRs & pushes from separate workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,15 +1,12 @@
 name: Build
 
 on:
-  push:
-  pull_request:
-
-# Group workflow runs by event and ref.
-# New runs cancel any pending run.
-# PR runs also cancel in-progress runs.
-concurrency:
-  group: build-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  workflow_call:
+    inputs:
+      matrix:
+        description: JSON build matrix
+        required: true
+        type: string
 
 permissions: {}
 
@@ -18,26 +15,16 @@ defaults:
     shell: bash
 
 jobs:
-  prepare:
-    name: Setup
-    uses: ./.github/workflows/prepare.yaml
-    permissions:
-      contents: read
-    with:
-      release: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' }}
-      matrix: true
-
   build:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
-    needs: prepare
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
+        include: ${{ fromJson(inputs.matrix) }}
     timeout-minutes: 120
 
     steps:
@@ -107,18 +94,3 @@ jobs:
             echo "_Expires on **$(date --utc --date=+"$upload_days"days +%F)** (UTC)._"
             echo
           ) >> "$GITHUB_STEP_SUMMARY"
-
-  publish:
-    if: github.event_name != 'push' || needs.prepare.outputs.do_release
-    name: Publish
-    uses: ./.github/workflows/publish.yaml
-    needs:
-      - prepare
-      - build
-    permissions:
-      contents: write
-    secrets:
-      MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-      CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
-    with:
-      dry-run: ${{ github.event_name != 'push' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,13 +1,7 @@
-name: Checks
+name: Lint
 
 on:
-  pull_request:
-
-# Group workflow runs by ref.
-# New runs cancel any pending run.
-# In-progress runs are allowed to complete.
-concurrency:
-  group: check-${{ github.ref }}
+  workflow_call:
 
 defaults:
   run:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,53 @@
+name: PR
+
+on:
+  pull_request:
+
+# Group workflow runs by PR number.
+# New runs cancel any pending run.
+# In-progress runs are asked to stop.
+concurrency:
+  group: pull_request-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Setup
+    uses: ./.github/workflows/prepare.yaml
+    permissions:
+      contents: read
+    with:
+      release: true
+      matrix: true
+
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yaml
+    permissions:
+      contents: read
+
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yaml
+    needs: prepare
+    permissions:
+      contents: read
+    with:
+      matrix: ${{ needs.prepare.outputs.matrix }}
+
+  publish:
+    name: Publish
+    uses: ./.github/workflows/publish.yaml
+    needs:
+      - prepare
+      - build
+    permissions:
+      contents: write # Needs to match publish.yaml job permissions
+    with:
+      dry-run: true

--- a/.github/workflows/pull_request_target.yaml
+++ b/.github/workflows/pull_request_target.yaml
@@ -12,7 +12,7 @@ on:
 # New runs cancel any pending run.
 # In-progress runs are allowed to complete.
 concurrency:
-  group: pr-comment-${{ github.event.number }}
+  group: pull_request_target-${{ github.event.number }}
 
 permissions: {}
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,50 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - main
+
+# Group workflow runs by ref.
+# New runs cancel any pending run.
+# In-progress runs are allowed to complete.
+concurrency:
+  group: push-${{ github.ref }}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prepare:
+    name: Setup
+    uses: ./.github/workflows/prepare.yaml
+    permissions:
+      contents: read
+    with:
+      release: true
+      matrix: true
+
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yaml
+    needs: prepare
+    permissions:
+      contents: read
+    with:
+      matrix: ${{ needs.prepare.outputs.matrix }}
+
+  publish:
+    if: needs.prepare.outputs.do_release
+    name: Publish
+    uses: ./.github/workflows/publish.yaml
+    needs:
+      - prepare
+      - build
+    permissions:
+      contents: write
+    secrets:
+      MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+      CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}


### PR DESCRIPTION
Introduce separate `push.yaml` and `pull_request.yaml` workflows, which delegate to reusable workflows. Rename `pr.yaml` → `pull_request_target.yaml` for consistency; all "root" workflows are now named after their triggering event.

This allows us to run a different set of jobs on push/pr without "push-specific-job: skipped" showing in PR checklists. For example, `lint.yaml` is run by `pull_request.yaml`, but not `push.yaml`. In the future, I will introduce a `create-release-pr.yaml`, which will be run from `push.yaml` but not `pull_request.yaml`.

