### PR TITLE
ci(create-release-pr): create release PRs on push

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -1,0 +1,86 @@
+name: Create Release PR
+on:
+  workflow_call:
+    secrets:
+      FREECAM_CI_APP_PRIVATE_KEY:
+        required: false # Falls back to `github.token`, e.g. on forks
+
+jobs:
+  create:
+    name: Create PR
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+
+    permissions:
+      # Use the same permissions as the freecam-ci app,
+      # for testing on forks where the app is not configured
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v3
+        if: vars.FREECAM_CI_APP_CLIENT_ID
+        id: app-token
+        with:
+          client-id: ${{ vars.FREECAM_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.FREECAM_CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - name: Get GitHub App User ID
+        id: app-id
+        if: steps.app-token.outputs.app-slug
+        env:
+          APP_USERNAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "app-id=$(gh api "/users/$APP_USERNAME" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        env:
+          APP_USER_ID: ${{ steps.app-id.outputs.app-id || '41898282' }}
+          APP_USERNAME: ${{ steps.app-token.outputs.app-slug || 'github-actions' }}[bot]
+        run: |
+          git config --global user.name "$APP_USERNAME"
+          git config --global user.email "$APP_USER_ID+$APP_USERNAME@users.noreply.github.com"
+
+      - name: Install Knope
+        uses: knope-dev/action@v2.1.2
+        with:
+          # TODO: keep up to date
+          version: 0.23.0
+
+      # `PrepareRelease` throws `releases::no_release` when there are no changes documented.
+      # `allow_empty` suppresses the error, but no release is prepared.
+      # See: https://github.com/knope-dev/knope/issues/2010
+      - name: Normalize changeset
+        run: |
+          shopt -s nullglob
+          changes=( .changeset/*.md )
+          if [ ${#changes[@]} = 0 ]; then
+            printf '%s\n'  '---' 'default: invalid' '---' > .changeset/empty.md
+          fi
+
+      - name: Create release branch
+        run: git switch -c "release/$GITHUB_REF_NAME"
+
+      - name: Cut release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          knope bump-version --verbose
+
+      - name: Create release PR
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          git push --force --set-upstream origin "release/$GITHUB_REF_NAME"
+          knope create-pr --verbose

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -27,6 +27,20 @@ jobs:
       release: true
       matrix: true
 
+  create_release_pr:
+    # Create a release PR unless this push event is the result of merging a release PR.
+    # If `prepare` finds un unpublished version, that means a release PR was merged.
+    if: ${{ !needs.prepare.outputs.do_release }}
+
+    name: Create Release PR
+    uses: ./.github/workflows/create-release-pr.yaml
+    needs: prepare
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      FREECAM_CI_APP_PRIVATE_KEY: ${{ secrets.FREECAM_CI_APP_PRIVATE_KEY }}
+
   build:
     name: Build
     uses: ./.github/workflows/build.yaml

--- a/knope.toml
+++ b/knope.toml
@@ -40,6 +40,24 @@ command = "git commit -m 'chore: release $version'"
 
 
 [[workflows]]
+name = "create-pr"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "main"
+
+[workflows.steps.title]
+template = "chore: release $version"
+
+[workflows.steps.body]
+template = """
+This PR was created by Knope. Merging it will create a new release.
+
+$changelog
+"""
+
+
+[[workflows]]
 name = "release"
 help_text = "Publish the current release"
 


### PR DESCRIPTION
Followup to #597

Introduce a new on:push workflow to create release PRs using Knope.

We use the same trigger (inverted) as for publishing releases, with the logic being that any push to 'main' that _isn't_ an already-prepared release, ready for publishing, is probably an in-development change that should be _previewed_ in a release PR.

Alternative strategies include checking `startsWith(github.event.head_commit.message, 'chore: release')` instead, which is simpler, but assumes a release PR only ever contains one commit.

