### PR TITLE
ci: introduce 'Required checks' meta-job

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -51,3 +51,33 @@ jobs:
       contents: write # Needs to match publish.yaml job permissions
     with:
       dry-run: true
+
+  # This meta-job exists only as a target for the 'required status checks' ruleset.
+  # It 'needs' all jobs that block merging a PR. Update the 'needs' list as CI requirements evolve.
+  status:
+    # Important: do not rename this job!
+    # The job name is the unique identifier used by required status checks.
+    name: Required checks
+    if: always()
+    runs-on: ubuntu-slim
+    permissions: {}
+
+    needs:
+      - lint
+      - build
+      - publish
+
+    steps:
+      - name: Check results
+        shell: python
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json, os, sys
+
+          ok = all(
+            result == "success"
+            for result in json.loads(os.environ["RESULTS"])
+          )
+
+          sys.exit(not ok)


### PR DESCRIPTION
Give branch rulesets a stable job name to target in our "required status checks".

This is inspired by what we do [in Nixpkgs](https://github.com/NixOS/nixpkgs/blob/0c57bb12426cdf87fcea5791106fda922f16cd58/.github/workflows/pull-request-target.yml#L139-L170) and what I do in my [personal config](https://github.com/MattSturgeon/nix-config/blob/78af2e29dcac550357cfce50551a7a4bb126d497/.github/workflows/check.yml#L73-L84) (which I'll probably update to use an implementation more like this).

Unlike the Nixpkgs implementation, which runs in a privileged `pull_request_target` workflow and can therefore use the API with `statuses: write` permissions, we use the workflow's job name itself as the required status check. This makes the approach compatible with unprivileged `pull_request` workflows originating from forks.

This also improves on the simple implementation currently in my personal config, which only runs when a dependency fails and is "skipped" otherwise. Here, the meta-job always runs and reads `needs.*.result` as JSON at runtime. It succeeds only when every required job has a `"success"` result; if any result is not `"success"`, the meta-job fails.
