### PR TITLE
ci(prepare): simplify 'do_release' → 'unreleased'

### DIFF
--- a/.github/workflows/prepare.yaml
+++ b/.github/workflows/prepare.yaml
@@ -12,7 +12,7 @@ on:
         type: boolean
         default: false
       release:
-        description: Check whether a release should be made
+        description: Check whether the current project version has been published on GitHub Releases
         type: boolean
         default: false
       matrix:
@@ -23,9 +23,9 @@ on:
       version:
         description: The current project version
         value: ${{ jobs.prepare.outputs.version }}
-      do_release:
-        description: Whether to publish a GitHub Release
-        value: ${{ jobs.prepare.outputs.do_release }}
+      unreleased:
+        description: Whether the current project version is not yet published on GitHub Releases
+        value: ${{ jobs.prepare.outputs.unreleased }}
       ci_files:
         description: Whether the PR touches files in 'ci' or '.github'
         value: ${{ jobs.prepare.outputs.ci_files }}
@@ -62,7 +62,7 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
-      do_release: ${{ steps.check_release.outputs.do_release }}
+      unreleased: ${{ steps.check_release.outputs.unreleased }}
       ci_files: ${{ steps.changed_files.outputs.ci }}
       i18n_files: ${{ steps.changed_files.outputs.i18n }}
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -154,7 +154,6 @@ jobs:
         with:
           script: |
             const tag = `v${process.env.VERSION}`
-            const push = context.eventName === "push"
             try {
               const { data } = await github.rest.repos.getReleaseByTag({ ...context.repo, tag })
               core.notice(`${tag} already published (${data.published_at})`)
@@ -162,7 +161,6 @@ jobs:
               if (err.status !== 404) throw err
               core.notice(`${tag} not published — creating release`)
               core.setOutput("unreleased", "true")
-              if (push) core.setOutput("do_release", "true")
             }
 
       - name: Generate build matrix

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -23,7 +23,6 @@ jobs:
     permissions:
       contents: read
     with:
-      release: true
       matrix: true
 
   lint:

--- a/.github/workflows/pull_request_target.yaml
+++ b/.github/workflows/pull_request_target.yaml
@@ -47,7 +47,7 @@ jobs:
         env:
           ci: ${{ needs.prepare.outputs.ci_files }}
           i18n: ${{ needs.prepare.outputs.i18n_files }}
-          release: ${{ needs.prepare.outputs.do_release }}
+          release: ${{ needs.prepare.outputs.unreleased }}
         run: |
           import json
           import os

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,7 @@ jobs:
   create_release_pr:
     # Create a release PR unless this push event is the result of merging a release PR.
     # If `prepare` finds un unpublished version, that means a release PR was merged.
-    if: ${{ !needs.prepare.outputs.do_release }}
+    if: ${{ !needs.prepare.outputs.unreleased }}
 
     name: Create Release PR
     uses: ./.github/workflows/create-release-pr.yaml
@@ -51,7 +51,7 @@ jobs:
       matrix: ${{ needs.prepare.outputs.matrix }}
 
   publish:
-    if: needs.prepare.outputs.do_release
+    if: needs.prepare.outputs.unreleased
     name: Publish
     uses: ./.github/workflows/publish.yaml
     needs:


### PR DESCRIPTION
When publishing and dry-run publishing were both orchestrated from a single `on:[push,pull_request]` workflow, `prepare` took extra care to only output `do_release` on 'push' events.

Now that orchestration is split, we can simplify the output to exactly what we're checking: "is the current project version released or not"

This fixes the pull_request_target managed 'release' label, because it was setting the label on 'do_release', which was never true for non-push events.
