### PR TITLE
ci(publish): pass Knope GitHub token correctly

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Publish GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           knope release ${{ inputs.dry-run && '--dry-run' || '' }}
 


### PR DESCRIPTION
`GH_TOKEN` is the name used by `gh`, while `knope` expects `GITHUB_TOKEN`.

This fixes Knope publishing 🤞
