### PR TITLE
ci(push): simplify 'Release PR / Create' job name

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create:
-    name: Create PR
+    name: Create
     runs-on: ubuntu-slim
     timeout-minutes: 10
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -32,7 +32,7 @@ jobs:
     # If `prepare` finds un unpublished version, that means a release PR was merged.
     if: ${{ !needs.prepare.outputs.unreleased }}
 
-    name: Create Release PR
+    name: Release PR
     uses: ./.github/workflows/create-release-pr.yaml
     needs: prepare
     permissions:


### PR DESCRIPTION
Before, it showed up in CI logs as "Create Release PR / Create PR", now it will be "Release PR / Create".
