### PR TITLE
ci(push): only build unreleased pushes

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,6 +42,11 @@ jobs:
       FREECAM_CI_APP_PRIVATE_KEY: ${{ secrets.FREECAM_CI_APP_PRIVATE_KEY }}
 
   build:
+    # Only build on:push when we need to publish a release
+    # Strictly speaking, we could run into cases where an outdated PR builds ok, but it fails when merged.
+    # However, we're much more likely to notice that now that we create release PRs on every push.
+    if: needs.prepare.outputs.unreleased
+
     name: Build
     uses: ./.github/workflows/build.yaml
     needs: prepare


### PR DESCRIPTION
Only build on push when we need to publish a release, otherwise save our CI usage for more important tasks.

Strictly speaking, we could run into cases where an outdated PR builds ok, but it fails when merged. However, we're much more likely to notice that scenario now that we create release PRs on every substantial push.
